### PR TITLE
More convenient builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,17 @@
-default:
-	npm install --build-from-source
+MODULE_NAME := $(shell node -e "console.log(require('./package.json').name)") 
+
+default: node_modules
+	./node_modules/.bin/node-pre-gyp build
 
 debug:
-	npm install --build-from-source --verbose
+	npm install --build-from-source=$(MODULE_NAME) --verbose
+
+clean:
+	rm -rf node_modules
+	rm -rf lib/binding
+
+node_modules:
+	npm install --build-from-source=$(MODULE_NAME)
 
 docs:
 	npm run docs

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MODULE_NAME := $(shell node -e "console.log(require('./package.json').name)") 
 
 default: node_modules
-	./node_modules/.bin/node-pre-gyp build
+	./node_modules/.bin/node-pre-gyp build --loglevel=error
 
 debug:
 	npm install --build-from-source=$(MODULE_NAME) --verbose


### PR DESCRIPTION
Per chat with @mapsam and @springmeyer , soup up the skeleton's Makefile with faster builds and "gotchyas" prevention.

Features:
- revised `default`: When running `make`, speeds up rebuilds when all that has changed is the cpp file you are editing. Skips rerunning npm install which is slow. This makes iterating through development faster as you make changes and test your changes.
- `make clean`: removes npm and mason deps
- `$(MODULE_NAME)`: convenience configuration/generalization

cc @mapsam @springmeyer 