### PR TITLE
Add Xcode project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,30 @@
-MODULE_NAME := $(shell node -e "console.log(require('./package.json').name)") 
+PACKAGE_NAME := $(shell node -e "console.log(require('./package.json').name)")
+MODULE_NAME := $(shell node -e "console.log(require('./package.json').binary.module_name)")
 
 default: node_modules
-	./node_modules/.bin/node-pre-gyp build --loglevel=error
+	./node_modules/.bin/node-pre-gyp configure build --loglevel=error
 
 debug:
-	npm install --build-from-source=$(MODULE_NAME) --verbose
+	npm install --build-from-source=$(PACKAGE_NAME) --verbose
 
 clean:
-	rm -rf node_modules
 	rm -rf lib/binding
+	rm -rf build
+
+distclean: clean
+	rm -rf node_modules
 
 node_modules:
-	npm install --build-from-source=$(MODULE_NAME)
+	npm install --build-from-source=$(PACKAGE_NAME)
+
+xcode: node_modules
+	./node_modules/.bin/node-pre-gyp configure -- -f xcode
+
+	@# If you need more targets, e.g. to run other npm scripts, duplicate the last line and change NPM_ARGUMENT
+	SCHEME_NAME="$(MODULE_NAME)" SCHEME_TYPE=library BLUEPRINT_NAME=$(MODULE_NAME) BUILDABLE_NAME=$(MODULE_NAME).node scripts/create_scheme.sh
+	SCHEME_NAME="npm test" SCHEME_TYPE=node BLUEPRINT_NAME=$(MODULE_NAME) BUILDABLE_NAME=$(MODULE_NAME).node NODE_ARGUMENT="`npm bin tape`/tape test/*.test.js" scripts/create_scheme.sh
+
+	open build/binding.xcodeproj
 
 docs:
 	npm run docs

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ make # build binaries
 make test
 ```
 
+# Xcode
+
+![npm-test scheme in Xcode](https://cloud.githubusercontent.com/assets/52399/16448893/4967a454-3df4-11e6-8bb5-701fe46174ef.png)
+
+If you're developing on macOS and have Xcode installed, you can also type `make xcode` to generate and open an Xcode project. In the dropdown, choose `npm test` to run the npm tests. You can also add more targets by adding the appropriate lines in `Makefile`, and rerunning `make xcode`. If you are modifying `binding.gyp`, e.g. by adding more source files, make sure to rerun `make xcode` so that Xcode knows about the new source files.
+
 # Usage
 
 ```javascript

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,8 @@
   'includes': [ 'common.gypi' ],
   'targets': [
     {
-      'target_name': 'hello_world',
+      'target_name': '<(module_name)',
+      'product_dir': '<(module_path)',
       'sources': [ './src/hello_world.cpp' ],
       'include_dirs': [
         '<!(node -e \'require("nan")\')'
@@ -21,17 +22,6 @@
         'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
         'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0'
       }
-    },
-    {
-      'target_name': 'action_after_build',
-      'type': 'none',
-      'dependencies': [ '<(module_name)' ],
-      'copies': [
-        {
-          'files': [ '<(PRODUCT_DIR)/<(module_name).node' ],
-          'destination': '<(module_path)'
-        }
-      ]
     }
   ]
 }

--- a/scripts/create_scheme.sh
+++ b/scripts/create_scheme.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -u
+
+CONTAINER=build/binding.xcodeproj
+OUTPUT="${CONTAINER}/xcshareddata/xcschemes/${SCHEME_NAME}.xcscheme"
+
+# Required ENV vars:
+# - SCHEME_TYPE: type of the scheme
+# - SCHEME_NAME: name of the scheme
+
+# Optional ENV vars:
+# - NODE_ARGUMENT (defaults to "")
+# - BUILDABLE_NAME (defaults ot SCHEME_NAME)
+# - BLUEPRINT_NAME (defaults ot SCHEME_NAME)
+
+
+# Try to reuse the existing Blueprint ID if the scheme already exists.
+if [ -f "${OUTPUT}" ]; then
+    BLUEPRINT_ID=$(sed -n "s/[ \t]*BlueprintIdentifier *= *\"\([A-Z0-9]\{24\}\)\"/\\1/p" "${OUTPUT}" | head -1)
+fi
+
+NODE_ARGUMENT=${NODE_ARGUMENT:-}
+BLUEPRINT_ID=${BLUEPRINT_ID:-$(hexdump -n 12 -v -e '/1 "%02X"' /dev/urandom)}
+BUILDABLE_NAME=${BUILDABLE_NAME:-${SCHEME_NAME}}
+BLUEPRINT_NAME=${BLUEPRINT_NAME:-${SCHEME_NAME}}
+
+mkdir -p "${CONTAINER}/xcshareddata/xcschemes"
+
+sed "\
+s#{{BLUEPRINT_ID}}#${BLUEPRINT_ID}#;\
+s#{{BLUEPRINT_NAME}}#${BLUEPRINT_NAME}#;\
+s#{{BUILDABLE_NAME}}#${BUILDABLE_NAME}#;\
+s#{{CONTAINER}}#${CONTAINER}#;\
+s#{{WORKING_DIRECTORY}}#$(pwd)#;\
+s#{{NODE_PATH}}#$(dirname `which node`)#;\
+s#{{NODE_ARGUMENT}}#${NODE_ARGUMENT}#" \
+    scripts/${SCHEME_TYPE}.xcscheme > "${OUTPUT}"

--- a/scripts/library.xcscheme
+++ b/scripts/library.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "{{BLUEPRINT_ID}}"
+               BuildableName = "{{BUILDABLE_NAME}}"
+               BlueprintName = "{{BLUEPRINT_NAME}}"
+               ReferencedContainer = "container:{{CONTAINER}}">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "{{BLUEPRINT_ID}}"
+            BuildableName = "{{BUILDABLE_NAME}}"
+            BlueprintName = "{{BLUEPRINT_NAME}}"
+            ReferencedContainer = "container:{{CONTAINER}}">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "{{BLUEPRINT_ID}}"
+            BuildableName = "{{BUILDABLE_NAME}}"
+            BlueprintName = "{{BLUEPRINT_NAME}}"
+            ReferencedContainer = "container:{{CONTAINER}}">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/scripts/node.xcscheme
+++ b/scripts/node.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "{{BLUEPRINT_ID}}"
+               BuildableName = "{{BUILDABLE_NAME}}"
+               BlueprintName = "{{BLUEPRINT_NAME}}"
+               ReferencedContainer = "container:{{CONTAINER}}">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "YES"
+      customWorkingDirectory = "{{WORKING_DIRECTORY}}"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "{{NODE_PATH}}/node">
+      </PathRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "{{BLUEPRINT_ID}}"
+            BuildableName = "{{BUILDABLE_NAME}}"
+            BlueprintName = "{{BLUEPRINT_NAME}}"
+            ReferencedContainer = "container:{{CONTAINER}}">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "{{NODE_ARGUMENT}}"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "PATH"
+            value = "{{NODE_PATH}}:$PATH"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "{{BLUEPRINT_ID}}"
+            BuildableName = "{{BUILDABLE_NAME}}"
+            BlueprintName = "{{BLUEPRINT_NAME}}"
+            ReferencedContainer = "container:{{CONTAINER}}">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
We should provide a way to create an Xcode project that compiles the node module and adds a schema to run `npm test`. This makes debugging node modules way easier on macOS.

/cc @mapsam @springmeyer @GretaCB 