### PR TITLE
Add easy way to get coverage results locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ debug:
 	git clone -b llvm-3.9.0 --depth 1 https://github.com/mapbox/mason .mason
 
 ./mason_packages/.link/bin/llvm-cov: ./.mason
-	./.mason/mason install llvm 3.9.0
-	./.mason/mason link llvm 3.9.0
+	./.mason/mason install clang++ 3.9.0
+	./.mason/mason link clang++ 3.9.0
+	./.mason/mason install llvm-cov 3.9.0
+	./.mason/mason link llvm-cov 3.9.0
 
 coverage: ./mason_packages/.link/bin/llvm-cov
 	./scripts/coverage.sh
@@ -24,6 +26,7 @@ clean:
 
 distclean: clean
 	rm -rf node_modules
+	rm -rf .mason
 
 node_modules:
 	npm install --build-from-source=$(PACKAGE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,18 @@ default: node_modules
 	./node_modules/.bin/node-pre-gyp configure build --loglevel=error
 
 debug:
-	npm install --build-from-source=$(PACKAGE_NAME) --debug --verbose
+	npm install --build-from-source=$(PACKAGE_NAME) --debug
+
+# TODO: pin to mason master once https://github.com/mapbox/mason/pull/253 is merged
+./.mason:
+	git clone -b llvm-3.9.0 --depth 1 https://github.com/mapbox/mason .mason
+
+./mason_packages/.link/bin/llvm-cov: ./.mason
+	./.mason/mason install llvm 3.9.0
+	./.mason/mason link llvm 3.9.0
+
+coverage: ./mason_packages/.link/bin/llvm-cov
+	./scripts/coverage.sh
 
 clean:
 	rm -rf lib/binding

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default: node_modules
 	./node_modules/.bin/node-pre-gyp configure build --loglevel=error
 
 debug:
-	npm install --build-from-source=$(PACKAGE_NAME) --verbose
+	npm install --build-from-source=$(PACKAGE_NAME) --debug --verbose
 
 clean:
 	rm -rf lib/binding

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -18,3 +18,5 @@ CXX_MODULE=$(./node_modules/.bin/node-pre-gyp reveal module --silent)
 $(pwd)/mason_packages/.link/bin/llvm-profdata merge -output=code.profdata code-*.profraw
 $(pwd)/mason_packages/.link/bin/llvm-cov report ${CXX_MODULE} -instr-profile=code.profdata -use-color
 $(pwd)/mason_packages/.link/bin/llvm-cov show ${CXX_MODULE} -instr-profile=code.profdata src/*.cpp -filename-equivalence -use-color
+$(pwd)/mason_packages/.link/bin/llvm-cov show ${CXX_MODULE} -instr-profile=code.profdata src/*.cpp -filename-equivalence -use-color --format html > /tmp/coverage.html
+echo "open /tmp/coverage.html for HTML version of this report"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+# http://clang.llvm.org/docs/UsersManual.html#profiling-with-instrumentation
+# https://www.bignerdranch.com/blog/weve-got-you-covered/
+
+export CXX="$(pwd)/mason_packages/.link/bin/clang++"
+export CXXFLAGS="-fprofile-instr-generate -fcoverage-mapping"
+export LDFLAGS="-fprofile-instr-generate"
+make debug
+rm -f *profraw
+rm -f *gcov
+rm -f *profdata
+LLVM_PROFILE_FILE="code-%p.profraw" npm test
+CXX_MODULE=$(./node_modules/.bin/node-pre-gyp reveal module --silent)
+$(pwd)/mason_packages/.link/bin/llvm-profdata merge -output=code.profdata code-*.profraw
+$(pwd)/mason_packages/.link/bin/llvm-cov report ${CXX_MODULE} -instr-profile=code.profdata -use-color
+$(pwd)/mason_packages/.link/bin/llvm-cov show ${CXX_MODULE} -instr-profile=code.profdata src/*.cpp -filename-equivalence -use-color


### PR DESCRIPTION
Waiting for travis and codecov.io to display results for coverage is not ideal. When developing we want immediate feedback. This adds a new Makefile shortcut `make coverage` that rebuilds the module with:

  - latest llvm 3.9.0 tools that have great support for coverage (based on tools only otherwise available in the xcode gui)
  - with the right flags
  - then automatically dumps and overall summary and a line-by-line display like:

Terminal report:

![screen shot 2016-10-10 at 9 00 04 pm](https://cloud.githubusercontent.com/assets/20300/19255524/e2aa83dc-8f2c-11e6-9348-66484047e8a9.png)

HTML report:

![screen shot 2016-10-10 at 9 08 33 pm](https://cloud.githubusercontent.com/assets/20300/19255607/bbfd52f4-8f2d-11e6-8096-aac4d2e8b9cc.png)

//cc @GretaCB @mapsam 
