### PR TITLE
-Werror and -isystem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ matrix:
         - ./scripts/publish.sh --toolset=${TOOLSET:-} --debug=$([ "${BUILDTYPE}" == 'debug' ] && echo "true" || echo "false")
     # g++ build (default builds all use clang++)
     - os: linux
-      env: BUILDTYPE=debug CXX="g++-6" CC="gcc-6"
+      env: BUILDTYPE=debug CXX="g++-6" CC="gcc-6" CXXFLAGS="-Weffc++"
       node_js: 4
       addons:
         apt:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 MODULE_NAME := $(shell node -e "console.log(require('./package.json').binary.module_name)")
 
+# Whether to turn compiler warnings into errors
+export WERROR ?= true
+
 default: release
 
 node_modules:
@@ -8,11 +11,11 @@ node_modules:
 	npm install --ignore-scripts
 
 release: node_modules
-	V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error
+	V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error
 	@echo "run 'make clean' for full rebuild"
 
 debug: node_modules
-	V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --debug
+	V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error --debug
 	@echo "run 'make clean' for full rebuild"
 
 coverage:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ make # build binaries
 make test
 ```
 
+Note: by default the build errors on compiler warnings. To disable this do:
+
+```
+WERROR=false make
+```
+
+
 # Code coverage
 
 Code coverage is critical for knowing how well your tests actually test all your code. To see code coverage you can view current results online at [![codecov](https://codecov.io/gh/mapbox/node-cpp-skel/branch/master/graph/badge.svg)](https://codecov.io/gh/mapbox/node-cpp-skel) or you can build in a customized way and display coverage locally like:

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,5 +1,8 @@
 {
   'includes': [ 'common.gypi' ],
+  'variables': {
+      'error_on_warnings%':'true'
+  },
   'targets': [
     {
       'target_name': '<(module_name)',
@@ -10,6 +13,14 @@
       ],
       'ldflags': [
         '-Wl,-z,now',
+      ],
+      'conditions': [
+        ['error_on_warnings != "false"', {
+            'cflags_cc' : [ '-Werror' ],
+            'xcode_settings': {
+              'OTHER_CPLUSPLUSFLAGS': [ '-Werror' ]
+            }
+        }]
       ],
       'xcode_settings': {
         'OTHER_LDFLAGS':[

--- a/binding.gyp
+++ b/binding.gyp
@@ -15,7 +15,7 @@
         '-Wl,-z,now',
       ],
       'conditions': [
-        ['error_on_warnings != "false"', {
+        ['error_on_warnings == "true"', {
             'cflags_cc' : [ '-Werror' ],
             'xcode_settings': {
               'OTHER_CPLUSPLUSFLAGS': [ '-Werror' ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,13 @@
 {
   'includes': [ 'common.gypi' ],
   'variables': {
-      'error_on_warnings%':'true'
+      'error_on_warnings%':'true',
+      # includes we don't want warnings for.
+      # As a variable to make easy to pass to
+      # cflags (linux) and xcode (mac)
+      'system_includes': [
+        "-isystem <(module_root_dir)/<!(node -e \"require('nan')\")"
+      ]
   },
   'targets': [
     {
@@ -22,9 +28,15 @@
             }
         }]
       ],
+      'cflags': [
+          '<@(system_includes)'
+      ],
       'xcode_settings': {
         'OTHER_LDFLAGS':[
           '-Wl,-bind_at_load'
+        ],
+        'OTHER_CPLUSPLUSFLAGS': [
+            '<@(system_includes)'
         ],
         'GCC_ENABLE_CPP_RTTI': 'YES',
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',

--- a/src/hello_world.cpp
+++ b/src/hello_world.cpp
@@ -119,6 +119,13 @@ NAN_METHOD(HelloWorld::wave)
 class AsyncBaton
 {
   public:
+    AsyncBaton() :
+      request(),
+      cb(),
+      phrase(),
+      louder(false),
+      error_name(),
+      result() {}
     uv_work_t request; // required
     Nan::Persistent<v8::Function> cb; // callback function type
     std::string phrase;


### PR DESCRIPTION
This makes two changes to the default build:

  - We now build with `-Werror` compiler flag: this changes compiler warnings to errors. The motivation here is that if you start with this behavior, it is easier to keep warning free.
  - We now use `-isystem` rather than `-I` to add paths for dependencies like `nan`. This avoids compiler warnings for code outside of scope to change. Refs #39