### PR TITLE
Mason

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 lib/binding
 node_modules
 build
+mason_packages
+.mason

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,12 @@ coverage:
 clean:
 	rm -rf lib/binding
 	rm -rf build
+	@echo "run 'make distclean' to also clear node_modules, mason_packages, and .mason directories"
 
 distclean: clean
 	rm -rf node_modules
+	rm -rf mason_packages
+	rm -rf .mason
 
 xcode: node_modules
 	./node_modules/.bin/node-pre-gyp configure -- -f xcode

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,13 +6,28 @@
       # As a variable to make easy to pass to
       # cflags (linux) and xcode (mac)
       'system_includes': [
-        "-isystem <(module_root_dir)/<!(node -e \"require('nan')\")"
+        "-isystem <(module_root_dir)/<!(node -e \"require('nan')\")",
+        "-isystem <(module_root_dir)/mason_packages/.link/include/"
       ]
   },
   'targets': [
     {
+      'target_name': 'action_before_build',
+      'type': 'none',
+      'hard_dependency': 1,
+      'actions': [
+        {
+          'action_name': 'install_deps',
+          'inputs': ['./scripts/install_deps.sh'],
+          'outputs': ['./mason_packages'],
+          'action': ['./scripts/install_deps.sh']
+        }
+      ]
+    },
+    {
       'target_name': '<(module_name)',
       'product_dir': '<(module_path)',
+      'dependencies': [ 'action_before_build' ],
       'sources': [ './src/hello_world.cpp' ],
       'include_dirs': [
         '<!(node -e \'require("nan")\')'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "test"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "tape test/*.test.js",
     "install": "node-pre-gyp install --fallback-to-build",
-    "docs": "documentation build src/*.cpp --polyglot -f md -o API.md"
+    "docs": "npm install ^4.0.0-beta5 && documentation build src/*.cpp --polyglot -f md -o API.md"
   },
   "author": "Mapbox",
   "license": "ISC",
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "aws-sdk": "^2.4.7",
-    "documentation": "^4.0.0-beta5",
     "tape": "^4.5.1"
   },
   "binary": {

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+function install() {
+  mason install $1 $2
+  mason link $1 $2
+}
+
+# setup mason
+./scripts/setup.sh --config local.env
+source local.env
+
+install protozero 1.5.1

--- a/src/hello_world.cpp
+++ b/src/hello_world.cpp
@@ -4,6 +4,8 @@
 #include <stdexcept>
 #include <iostream>
 
+#include <protozero/pbf_reader.hpp>
+
 // Custom constructor added in order to test/cover throwing an error during initialization
 HelloWorld::HelloWorld(std::string name) : 
   name_(name) {


### PR DESCRIPTION
Increasingly I'm seeing that the majority of node C++ addons being created anew at @mapbox are depending on mason deps. This moves the skel to including the basic scaffolding to make this easy,  including:

  - Adding a script `install_deps.sh` to install deps (in this case we install protozero as an example of a lib you might use)
  - Making `install_deps.sh` run when `npm install --build-from-source` runs.

Learning from https://github.com/mapbox/carmen-cache/pull/63 and https://github.com/mapbox/node-fontnik/pull/128