### PR TITLE
Add object-sync example

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -37,7 +37,7 @@
         './src/module.cpp',
         './src/standalone/hello.cpp',
         './src/standalone_async/hello_async.cpp',
-        './src/hello_world.cpp'
+        './src/object_sync/hello.cpp'
       ],
       'include_dirs': [
         '<!(node -e \'require("nan")\')'

--- a/src/hello_world.cpp
+++ b/src/hello_world.cpp
@@ -44,7 +44,7 @@ NAN_METHOD(HelloWorld::New)
             }
             else {
                 auto *const self = new HelloWorld();
-                self->Wrap(info.This());
+                self->Wrap(info.This()); // Connects C++ object to Javascript object (this)
             } 
 
         }
@@ -64,6 +64,7 @@ NAN_METHOD(HelloWorld::New)
 
 Nan::Persistent<v8::Function> &HelloWorld::constructor()
 {
+
     static Nan::Persistent<v8::Function> init;
     return init;
 }
@@ -260,6 +261,7 @@ void HelloWorld::AfterShout(uv_work_t* req)
     delete baton;
 }
 
+// called when "require" in Javascript world
 NAN_MODULE_INIT(HelloWorld::Init)
 {
     const auto whoami = Nan::New("HelloWorld").ToLocalChecked();
@@ -271,8 +273,8 @@ NAN_MODULE_INIT(HelloWorld::Init)
     // custom methods added here
     SetPrototypeMethod(fnTp, "wave", wave);
     SetPrototypeMethod(fnTp, "shout", shout);
-
+    
     const auto fn = Nan::GetFunction(fnTp).ToLocalChecked();
-    constructor().Reset(fn);
+    constructor().Reset(fn); // calling the static &HelloWorld constructor method
     Nan::Set(target, whoami, fn);
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -17,6 +17,10 @@ static void init(v8::Local<v8::Object> target) {
     // expose HelloObject class
     object_sync::HelloObject::Init(target);
 
+    // Notice there are multiple "hello" functions as part of this module:
+    // 1) standalone::hello
+    // 2) HelloObject.hello()...not really sure why this function doesnt have to be expliclty exposed
+
     // add more methods/classes below that youd like to use in node.js-world
     // then create a .cpp and .hpp file in /src for each new method
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -16,13 +16,16 @@ static void init(v8::Local<v8::Object> target) {
 
     // expose HelloObject class
     object_sync::HelloObject::Init(target);
+    
+   /**
+    * You may have noticed there are multiple "hello" functions as part of this module.
+    * They are both exposed a bit differently.
+    * 1) standalone::hello    // exposed above
+    * 2) HelloObject.hello    // exposed in object_sync/hello.cpp as part of HelloObject
+    */
 
-    // Notice there are multiple "hello" functions as part of this module:
-    // 1) standalone::hello
-    // 2) HelloObject.hello()...not really sure why this function doesnt have to be expliclty exposed
-
-    // add more methods/classes below that youd like to use in node.js-world
-    // then create a .cpp and .hpp file in /src for each new method
+    // add more methods/classes below that youd like to use in Javascript world
+    // then create a directory in /src with a .cpp and a .hpp file
 }
 
 NODE_MODULE(module, init)

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -5,7 +5,7 @@
 // #include "your_code.hpp"
 
 // "target" is a magic var that nodejs passes into modules scope
-// When you write things to target, they become available to call from js
+// When you write things to target, they become available to call from Javascript world
 static void init(v8::Local<v8::Object> target) {
 
     // expose hello method

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -17,9 +17,6 @@ static void init(v8::Local<v8::Object> target) {
     // expose HelloObject class
     object_sync::HelloObject::Init(target);
 
-    // expose hello method from HelloObject class
-    Nan::SetMethod(target, "hello", object_sync::HelloObject::hello);
-
     // add more methods/classes below that youd like to use in node.js-world
     // then create a .cpp and .hpp file in /src for each new method
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1,7 +1,7 @@
 #include <nan.h>
 #include "standalone/hello.hpp"
 #include "standalone_async/hello_async.hpp"
-#include "hello_world.hpp"
+#include "object_sync/hello.hpp"
 // #include "your_code.hpp"
 
 // "target" is a magic var that nodejs passes into modules scope
@@ -14,8 +14,11 @@ static void init(v8::Local<v8::Object> target) {
     // expose hello_async method
     Nan::SetMethod(target, "hello_async", standalone_async::hello_async);
 
-    // expose hello_world class
-    HelloWorld::Init(target);
+    // expose HelloObject class
+    object_sync::HelloObject::Init(target);
+
+    // expose hello method from HelloObject class
+    Nan::SetMethod(target, "hello", object_sync::HelloObject::hello);
 
     // add more methods/classes below that youd like to use in node.js-world
     // then create a .cpp and .hpp file in /src for each new method

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -51,7 +51,7 @@ namespace object_sync {
   // If this function was not defined within a namespace, it would be in the global scope.
   // NAN_METHOD is applicable to methods you want to expose to JS world
   NAN_METHOD(HelloObject::hello) {
-
+    // Note: a HandleScope is automatically included inside NAN_METHOD (TODO: confirm/find link to this)
     HelloObject* h = Nan::ObjectWrap::Unwrap<HelloObject>(info.Holder());
 
     // "info" comes from the NAN_METHOD macro, which returns differently
@@ -61,7 +61,7 @@ namespace object_sync {
   }
   
   // Singleton...not really sure what to say about this
-  Nan::Persistent<v8::Function> &HelloObject::constructor()
+  Nan::Persistent<v8::Function> &HelloObject::create_once()
   {
       static Nan::Persistent<v8::Function> init;
       return init;
@@ -69,10 +69,10 @@ namespace object_sync {
 
   void HelloObject::Init(v8::Local<v8::Object> target)
   {
-  	  // This is saying: 
-  	  // "Node, please allocate a new Javascript string object 
-  	  // inside the V8 memory space, with the value 'HelloObject' "
-      const auto whoami = Nan::New("HelloObject").ToLocalChecked();  
+      // This is saying:
+      // "Node, please allocate a new Javascript string object
+      // inside the V8 local memory space, with the value 'HelloObject' "
+      v8::Local<v8::String> whoami = Nan::New("HelloObject").ToLocalChecked();
        
       // Create the HelloObject
       auto fnTp = Nan::New<v8::FunctionTemplate>(HelloObject::New); // Passing the HelloObject::New method above
@@ -89,7 +89,7 @@ namespace object_sync {
       // Create an unique instance of the HelloObject function template,
       // then set this unique instance to the target
       const auto fn = Nan::GetFunction(fnTp).ToLocalChecked();
-      constructor().Reset(fn);  // calls the static &HelloObject::constructor method above. This ensures the instructions in this Init function are retained in memory even after this code block ends.
+      create_once().Reset(fn);  // calls the static &HelloObject::constructor method above. This ensures the instructions in this Init function are retained in memory even after this code block ends.
       Nan::Set(target, whoami, fn);
   }
 

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -52,9 +52,11 @@ namespace object_sync {
   // NAN_METHOD is applicable to methods you want to expose to JS world
   NAN_METHOD(HelloObject::hello) {
 
+    HelloObject* h = Nan::ObjectWrap::Unwrap<HelloObject>(info.Holder());
+
     // "info" comes from the NAN_METHOD macro, which returns differently
     // according to the version of node
-    info.GetReturnValue().Set(Nan::New<v8::String>("...initialized an object..." + name_).ToLocalChecked()); // ???
+    info.GetReturnValue().Set(Nan::New<v8::String>("...initialized an object..." + h->name_).ToLocalChecked()); // ???
   
   }
   

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -56,7 +56,7 @@ namespace object_sync {
 
     // "info" comes from the NAN_METHOD macro, which returns differently
     // according to the version of node
-    info.GetReturnValue().Set(Nan::New<v8::String>("...initialized an object..." + h->name_).ToLocalChecked()); // ???
+    info.GetReturnValue().Set(Nan::New<v8::String>("...initialized an object...hello " + h->name_).ToLocalChecked()); // ???
   
   }
   

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -3,11 +3,11 @@
 // If this was not defined within a namespace, it would be in the global scope.
 namespace object_sync {
 
-  // Custom constructor, assigns custom name passed in from Javascript world
+  // Custom constructor, assigns custom name passed in from Javascript world.
+  // This constructor uses member init list via the semicolon, aka "direct initialization" 
+  // which is more efficient than using assignment operators.
   HelloObject::HelloObject(std::string name) : 
-    name_(name) {
-    name = name_; // And how would I later use this name property in the hello method?
-  }
+    name_(name) {}
 
   // Triggered from Javascript world when calling "new HelloObject()" or "new HelloObject(name)"
   NAN_METHOD(HelloObject::New) {

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -51,7 +51,10 @@ namespace object_sync {
   // If this function was not defined within a namespace, it would be in the global scope.
   // NAN_METHOD is applicable to methods you want to expose to JS world
   NAN_METHOD(HelloObject::hello) {
-    // Note: a HandleScope is automatically included inside NAN_METHOD (TODO: confirm/find link to this)
+    // Note: a HandleScope is automatically included inside NAN_METHOD (See the docs at NAN that say:
+    // 'Note that an implicit HandleScope is created for you on JavaScript-accessible methods so you do not need to insert one yourself.'
+    // at https://github.com/nodejs/nan/blob/2dfc5c2d19c8066903a19ced6a72c06d2c825dec/doc/scopes.md#nanhandlescope
+
     HelloObject* h = Nan::ObjectWrap::Unwrap<HelloObject>(info.Holder());
 
     // "info" comes from the NAN_METHOD macro, which returns differently
@@ -69,6 +72,12 @@ namespace object_sync {
 
   void HelloObject::Init(v8::Local<v8::Object> target)
   {
+      // A handlescope is needed so that v8 objects created in the local memory space (this function in this case)
+      // are cleaned up when the function is done running (and the handlescope is destroyed)
+      // Fun trivia: forgetting a handlescope is one of the most common causes of memory leaks in node.js core
+      // https://www.joyent.com/blog/walmart-node-js-memory-leak
+      Nan::HandleScope scope;
+
       // This is saying:
       // "Node, please allocate a new Javascript string object
       // inside the V8 local memory space, with the value 'HelloObject' "

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -1,0 +1,14 @@
+#include "hello.hpp"
+
+namespace object_sync {
+
+  // hello is a "standalone function" because it's not a class.
+  // If this function was not defined within a namespace, it would be in the global scope.
+  NAN_METHOD(hello) {
+
+    // "info" comes from the NAN_METHOD macro, which returns differently
+    // according to the version of node
+    info.GetReturnValue().Set(Nan::New<v8::String>("world").ToLocalChecked());
+  
+  }
+} // namespace standalone

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -3,10 +3,9 @@
 namespace object_sync {
   
   // If this function was not defined within a namespace, it would be in the global scope.
-  NAN_METHOD(HelloObject::New) {
+  NAN_METHOD(HelloObject::New) {}
 
-  
-  }
+  // Add constructor?
 
   // If this function was not defined within a namespace, it would be in the global scope.
   NAN_METHOD(HelloObject::hello) {

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -1,14 +1,38 @@
 #include "hello.hpp"
 
 namespace object_sync {
-
-  // hello is a "standalone function" because it's not a class.
+  
   // If this function was not defined within a namespace, it would be in the global scope.
-  NAN_METHOD(hello) {
+  NAN_METHOD(HelloObject::New) {
+
+  
+  }
+
+  // If this function was not defined within a namespace, it would be in the global scope.
+  NAN_METHOD(HelloObject::hello) {
 
     // "info" comes from the NAN_METHOD macro, which returns differently
     // according to the version of node
-    info.GetReturnValue().Set(Nan::New<v8::String>("world").ToLocalChecked());
+    info.GetReturnValue().Set(Nan::New<v8::String>("...initialized an object...world").ToLocalChecked());
   
   }
-} // namespace standalone
+
+  NAN_MODULE_INIT(HelloObject::Init)
+  {
+  	  // Add comments...not sure what this is doing
+      const auto whoami = Nan::New("HelloObject").ToLocalChecked();  
+
+      // Add comments...not sure what this is doing
+      auto fnTp = Nan::New<v8::FunctionTemplate>(New);
+      fnTp->InstanceTemplate()->SetInternalFieldCount(1);
+      fnTp->SetClassName(whoami);  
+
+      // custom methods added here
+      SetPrototypeMethod(fnTp, "hello", hello); 
+
+      // Add comments...not sure what this is doing
+      const auto fn = Nan::GetFunction(fnTp).ToLocalChecked();
+      Nan::Set(target, whoami, fn);
+  }
+
+} // namespace object_sync

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -1,13 +1,20 @@
 #include "hello.hpp"
 
+  // If this was not defined within a namespace, it would be in the global scope.
 namespace object_sync {
   
-  // If this function was not defined within a namespace, it would be in the global scope.
-  NAN_METHOD(HelloObject::New) {}
+  // Default constructor
+  NAN_METHOD(HelloObject::New) {
 
-  // Add constructor?
+    if (!info.IsConstructCall())
+    {
+        return Nan::ThrowTypeError(
+            "Cannot call constructor as function, you need to use 'new' keyword");
+    }
+  }
 
   // If this function was not defined within a namespace, it would be in the global scope.
+  // NAN_METHOD is applicable to methods you want to expose to JS world
   NAN_METHOD(HelloObject::hello) {
 
     // "info" comes from the NAN_METHOD macro, which returns differently
@@ -16,20 +23,26 @@ namespace object_sync {
   
   }
 
-  NAN_MODULE_INIT(HelloObject::Init)
+  void HelloObject::Init(v8::Local<v8::Object> target)
   {
-  	  // Add comments...not sure what this is doing
+  	  // This is saying: 
+  	  // "Node, please allocate a new Javascript string object 
+  	  // inside the V8 memory space, with the value 'HelloObject' "
       const auto whoami = Nan::New("HelloObject").ToLocalChecked();  
+       
+      // Create the HelloObject
+      auto fnTp = Nan::New<v8::FunctionTemplate>(HelloObject::New); // Passing the HelloObject::New constructor above
+      fnTp->InstanceTemplate()->SetInternalFieldCount(1); // It's 1 when holding the ObjectWrap itself and nothing else
+      fnTp->SetClassName(whoami); // Passing the Javascript string object above
 
-      // Add comments...not sure what this is doing
-      auto fnTp = Nan::New<v8::FunctionTemplate>(New);
-      fnTp->InstanceTemplate()->SetInternalFieldCount(1);
-      fnTp->SetClassName(whoami);  
+      // Add custom methods here.
+      // This line is attaching the "hello" method to a JavaScript function prototype.
+      // "hello" is therefore like a property of the fnTp object 
+      // ex: console.log(HelloObject.hello) --> [Function: hello]
+      SetPrototypeMethod(fnTp, "hello", hello);
 
-      // custom methods added here
-      SetPrototypeMethod(fnTp, "hello", hello); 
-
-      // Add comments...not sure what this is doing
+      // Create an unique instance of the HelloObject function template,
+      // then set this unique instance to the target
       const auto fn = Nan::GetFunction(fnTp).ToLocalChecked();
       Nan::Set(target, whoami, fn);
   }

--- a/src/object_sync/hello.hpp
+++ b/src/object_sync/hello.hpp
@@ -14,13 +14,23 @@ namespace object_sync {
             // initializer
             static void Init(v8::Local<v8::Object> target);
 
-            // methods required for the constructor
+            // methods required for the V8 constructor (?)
             static NAN_METHOD(New);
-            //static Nan::Persistent<v8::Function> &constructor();
+            static Nan::Persistent<v8::Function> &constructor();
 
-            // hello, custom sync method tied to Init of this class somehow...?
-            // method's logic lives in hello.cpp
+            // hello, custom sync method tied to Init of this class
+            // method's logic lives in ./hello.cpp
             static NAN_METHOD(hello);
+
+            // C++ Constructor
+            // This includes a Default Argument
+            // If a parameter value is passed in, it takes priority over the default arg
+            HelloObject(std::string name="world");
+
+        private:
+            // member variable
+            // specific to each instance of the class
+            std::string name_;
 
 	};
 

--- a/src/object_sync/hello.hpp
+++ b/src/object_sync/hello.hpp
@@ -18,7 +18,7 @@ namespace object_sync {
             static NAN_METHOD(New);
             //static Nan::Persistent<v8::Function> &constructor();
 
-            // hello, custom sync method tied to module.cpp
+            // hello, custom sync method tied to Init of this class somehow...?
             // method's logic lives in hello.cpp
             static NAN_METHOD(hello);
 

--- a/src/object_sync/hello.hpp
+++ b/src/object_sync/hello.hpp
@@ -16,11 +16,11 @@ namespace object_sync {
 
             // methods required for the constructor
             static NAN_METHOD(New);
-            // static Nan::Persistent<v8::Function> &constructor();
+            //static Nan::Persistent<v8::Function> &constructor();
 
             // hello, custom sync method tied to module.cpp
             // method's logic lives in hello.cpp
-            NAN_METHOD(hello);
+            static NAN_METHOD(hello);
 
 	};
 

--- a/src/object_sync/hello.hpp
+++ b/src/object_sync/hello.hpp
@@ -12,7 +12,7 @@ namespace object_sync {
 
         public:
             // initializer
-            static NAN_MODULE_INIT(Init);
+            static void Init(v8::Local<v8::Object> target);
 
             // methods required for the constructor
             static NAN_METHOD(New);

--- a/src/object_sync/hello.hpp
+++ b/src/object_sync/hello.hpp
@@ -16,7 +16,7 @@ namespace object_sync {
 
             // methods required for the V8 constructor (?)
             static NAN_METHOD(New);
-            static Nan::Persistent<v8::Function> &constructor();
+            static Nan::Persistent<v8::Function> &create_once();
 
             // hello, custom sync method tied to Init of this class
             // method's logic lives in ./hello.cpp

--- a/src/object_sync/hello.hpp
+++ b/src/object_sync/hello.hpp
@@ -4,15 +4,23 @@
 namespace object_sync {
 
     /**
-     * HelloWorld class
+     * HelloObject class
      * This is in a header file so we can access it across other .cpp files if necessary
      * Also, this class adheres to the rule of Zero because we define no custom destructor or copy constructor
      */
-    class Hello: public Nan::ObjectWrap {
-	    
-	    // hello, custom sync method tied to module.cpp
-	    // method's logic lives in hello.cpp
-	    NAN_METHOD(hello);
+    class HelloObject: public Nan::ObjectWrap {
+
+        public:
+            // initializer
+            static NAN_MODULE_INIT(Init);
+
+            // methods required for the constructor
+            static NAN_METHOD(New);
+            // static Nan::Persistent<v8::Function> &constructor();
+
+            // hello, custom sync method tied to module.cpp
+            // method's logic lives in hello.cpp
+            NAN_METHOD(hello);
 
 	};
 

--- a/src/object_sync/hello.hpp
+++ b/src/object_sync/hello.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <nan.h>
+
+namespace object_sync {
+
+    /**
+     * HelloWorld class
+     * This is in a header file so we can access it across other .cpp files if necessary
+     * Also, this class adheres to the rule of Zero because we define no custom destructor or copy constructor
+     */
+    class Hello: public Nan::ObjectWrap {
+	    
+	    // hello, custom sync method tied to module.cpp
+	    // method's logic lives in hello.cpp
+	    NAN_METHOD(hello);
+
+	};
+
+}

--- a/src/standalone/hello.cpp
+++ b/src/standalone/hello.cpp
@@ -17,7 +17,7 @@ namespace standalone {
 
     // "info" comes from the NAN_METHOD macro, which returns differently
     // according to the version of node
-    info.GetReturnValue().Set(Nan::New<v8::String>("world").ToLocalChecked());
+    info.GetReturnValue().Set(Nan::New<v8::String>("hello world").ToLocalChecked());
   
   }
 } // namespace standalone

--- a/test/hello.test.js
+++ b/test/hello.test.js
@@ -3,7 +3,7 @@ var module = require('../lib/index.js');
 
 test('prints world', function(t) {
   var check = module.hello();
-  t.equal(check, 'world', 'returned world');
+  t.equal(check, 'hello world', 'returned world');
   t.end();
 });
 

--- a/test/hello_object.test.js
+++ b/test/hello_object.test.js
@@ -7,3 +7,13 @@ test('success: prints expected string', function(t) {
   t.equal(check, '...initialized an object...world', 'returned expected string');
   t.end();
 });
+
+test('error: throws when missing "new"', function(t) {
+  try {
+    var H = module.HelloObject();
+  } catch(err) {
+    t.ok(err);
+    t.equal(err.message, 'Cannot call constructor as function, you need to use \'new\' keyword', 'expected error message')
+    t.end();
+  }
+});

--- a/test/hello_object.test.js
+++ b/test/hello_object.test.js
@@ -4,7 +4,14 @@ var module = require('../lib/index.js');
 test('success: prints expected string', function(t) {
   var H = new module.HelloObject();
   var check = H.hello();
-  t.equal(check, '...initialized an object...world', 'returned expected string');
+  t.equal(check, '...initialized an object...hello world', 'returned expected string');
+  t.end();
+});
+
+test('success: prints expected string', function(t) {
+  var H = new module.HelloObject('carol');
+  var check = H.hello();
+  t.equal(check, '...initialized an object...hello carol', 'returned expected string');
   t.end();
 });
 

--- a/test/hello_object.test.js
+++ b/test/hello_object.test.js
@@ -1,0 +1,9 @@
+var test = require('tape');
+var module = require('../lib/index.js');
+
+test('success: prints expected string', function(t) {
+  var H = new module.HelloObject();
+  var check = H.hello();
+  t.equal(check, '...initialized an object...world', 'returned expected string');
+  t.end();
+});

--- a/test/hello_world.test.js
+++ b/test/hello_world.test.js
@@ -1,120 +1,120 @@
-var test = require('tape');
-var module = require('../lib/index.js');
-var HW = new module.HelloWorld();
+// var test = require('tape');
+// var module = require('../lib/index.js');
+// var HW = new module.HelloWorld();
 
-test('HellowWorld error - throw exception during construction', function(t) {
-  var never = '';
-  try {
-    var HWuhoh = new module.HelloWorld('uhoh');
-    never = 'neverland';
-  } catch (err) {
-      t.ok(err, 'expected error');
-  }
-  t.equals(never, '', 'constructor definitely throws');
-  t.end();
-});
+// test('HellowWorld error - throw exception during construction', function(t) {
+//   var never = '';
+//   try {
+//     var HWuhoh = new module.HelloWorld('uhoh');
+//     never = 'neverland';
+//   } catch (err) {
+//       t.ok(err, 'expected error');
+//   }
+//   t.equals(never, '', 'constructor definitely throws');
+//   t.end();
+// });
 
-test('HellowWorld error - throw type error during construction', function(t) {
-  var never = '';
-  try {
-    var HWuhoh = new module.HelloWorld(24);
-    never = 'neverland';
-  } catch (err) {
-      t.ok(err, 'expected error');
-      t.equals(err.message, 'arg must be a string')
-  }
-  t.equals(never, '', 'constructor definitely throws');
-  t.end();
-});
+// test('HellowWorld error - throw type error during construction', function(t) {
+//   var never = '';
+//   try {
+//     var HWuhoh = new module.HelloWorld(24);
+//     never = 'neverland';
+//   } catch (err) {
+//       t.ok(err, 'expected error');
+//       t.equals(err.message, 'arg must be a string')
+//   }
+//   t.equals(never, '', 'constructor definitely throws');
+//   t.end();
+// });
 
-test('HellowWorld error - invalid constructor', function(t) {
-  var never = '';
-  try {
-    var HWuhoh = module.HelloWorld();
-    never = 'neverland';
-  } catch (err) {
-      t.ok(err, 'expected error');
-      t.equals(err.message, "Cannot call constructor as function, you need to use 'new' keyword");
-  }
-  t.equals(never, '', 'constructor definitely throws');
-  t.end();
-});
+// test('HellowWorld error - invalid constructor', function(t) {
+//   var never = '';
+//   try {
+//     var HWuhoh = module.HelloWorld();
+//     never = 'neverland';
+//   } catch (err) {
+//       t.ok(err, 'expected error');
+//       t.equals(err.message, "Cannot call constructor as function, you need to use 'new' keyword");
+//   }
+//   t.equals(never, '', 'constructor definitely throws');
+//   t.end();
+// });
 
-test('HellowWorld success - valid constructor', function(t) {
-  var never = '';
-  try {
-    var HWyay = new module.HelloWorld('hello');
-    never = 'neverland';
-  } catch (err) {
-      if (err) throw err;
-  }
-  t.equals(never, 'neverland', 'constructor definitely succeeds');
-  t.end();
-});
-
-
-test('wave success', function(t) {
-  var hello = HW.wave();
-  t.equal(hello, 'howdy world', 'output of HelloWorld.wave');
-  t.end();
-});
-
-test('shout success', function(t) {
-  HW.shout('rawr', {}, function(err, shout) {
-    if (err) throw err;
-    t.equal(shout, 'rawr!');
-    t.end();
-  });
-});
-
-test('shout success - options.louder', function(t) {
-  HW.shout('rawr', { louder: true }, function(err, shout) {
-    if (err) throw err;
-    t.equal(shout, 'rawr!!!!!');
-    t.end();
-  });
-});
+// test('HellowWorld success - valid constructor', function(t) {
+//   var never = '';
+//   try {
+//     var HWyay = new module.HelloWorld('hello');
+//     never = 'neverland';
+//   } catch (err) {
+//       if (err) throw err;
+//   }
+//   t.equals(never, 'neverland', 'constructor definitely succeeds');
+//   t.end();
+// });
 
 
-test('shout error - not enough rawr', function(t) {
-  HW.shout('tiny moo', { louder: true }, function(err, shout) {
-    t.ok(err, 'expected error');
-    t.ok(err.message.indexOf('rawr all the time') > -1, 'rawrs all the time are way nicer');
-    t.end();
-  });
-});
+// test('wave success', function(t) {
+//   var hello = HW.wave();
+//   t.equal(hello, 'howdy world', 'output of HelloWorld.wave');
+//   t.end();
+// });
 
-test('shout error - non string phrase', function(t) {
-  HW.shout(4, {}, function(err, shout) {
-    t.ok(err, 'expected error');
-    t.ok(err.message.indexOf('phrase') > -1, 'proper error message');
-    t.end();
-  });
-});
+// test('shout success', function(t) {
+//   HW.shout('rawr', {}, function(err, shout) {
+//     if (err) throw err;
+//     t.equal(shout, 'rawr!');
+//     t.end();
+//   });
+// });
 
-test('shout error - no options object', function(t) {
-  HW.shout('rawr', true, function(err, shout) {
-    t.ok(err, 'expected error');
-    t.ok(err.message.indexOf('options') > -1, 'proper error message');
-    t.end();
-  });
-});
+// test('shout success - options.louder', function(t) {
+//   HW.shout('rawr', { louder: true }, function(err, shout) {
+//     if (err) throw err;
+//     t.equal(shout, 'rawr!!!!!');
+//     t.end();
+//   });
+// });
 
-test('shout error - options.louder non boolean', function(t) {
-  HW.shout('rawr', { louder: 3 }, function(err, shout) {
-    t.ok(err, 'expected error');
-    t.ok(err.message.indexOf('louder') > -1, 'proper error message');
-    t.end();
-  });
-});
 
-// we have to try/catch since a missing callback results in a throw
-test('shout error - no callback', function(t) {
-  try {
-    HW.shout('rawr', {});
-  } catch (err) {
-    t.ok(err, 'expected error');
-    t.ok(err.message.indexOf('callback') > -1, 'proper error message');
-    t.end();
-  }
-});
+// test('shout error - not enough rawr', function(t) {
+//   HW.shout('tiny moo', { louder: true }, function(err, shout) {
+//     t.ok(err, 'expected error');
+//     t.ok(err.message.indexOf('rawr all the time') > -1, 'rawrs all the time are way nicer');
+//     t.end();
+//   });
+// });
+
+// test('shout error - non string phrase', function(t) {
+//   HW.shout(4, {}, function(err, shout) {
+//     t.ok(err, 'expected error');
+//     t.ok(err.message.indexOf('phrase') > -1, 'proper error message');
+//     t.end();
+//   });
+// });
+
+// test('shout error - no options object', function(t) {
+//   HW.shout('rawr', true, function(err, shout) {
+//     t.ok(err, 'expected error');
+//     t.ok(err.message.indexOf('options') > -1, 'proper error message');
+//     t.end();
+//   });
+// });
+
+// test('shout error - options.louder non boolean', function(t) {
+//   HW.shout('rawr', { louder: 3 }, function(err, shout) {
+//     t.ok(err, 'expected error');
+//     t.ok(err.message.indexOf('louder') > -1, 'proper error message');
+//     t.end();
+//   });
+// });
+
+// // we have to try/catch since a missing callback results in a throw
+// test('shout error - no callback', function(t) {
+//   try {
+//     HW.shout('rawr', {});
+//   } catch (err) {
+//     t.ok(err, 'expected error');
+//     t.ok(err.message.indexOf('callback') > -1, 'proper error message');
+//     t.end();
+//   }
+// });


### PR DESCRIPTION
Per https://github.com/mapbox/node-cpp-skel/pull/44, continuing to expand examples. Super rough right now.

- This object-sync example builds off the sync standalone example,  but implements it as part of a `Class`
- Not sure the `hello` framing is very intuitive, so pondering better object use-cases/metaphors
- Gradually removing `src/hello_world.cpp`, and replacing parts of it with this example, and pondering what pieces are best to break apart into other examples

cc @mapbox/core-tech 