### PR TITLE
Add example of setting custom error code in C++

### DIFF
--- a/src/module_utils.hpp
+++ b/src/module_utils.hpp
@@ -18,8 +18,11 @@ namespace utils {
   * 
   */
   inline void CallbackError(std::string message, v8::Local<v8::Function> callback) {
-  	v8::Local<v8::Value> argv[1] = { Nan::Error(message.c_str()) };
-  	Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 1, argv);
+    v8::Local<v8::Value> err = Nan::Error(message.c_str());
+    v8::Local<v8::Object> err_obj = err->ToObject();
+    err_obj->Set(Nan::New("code").ToLocalChecked(),Nan::New("EHELLOERROR").ToLocalChecked());
+    v8::Local<v8::Value> argv[1] = { err };
+    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 1, argv);
   }
 
 }

--- a/test/hello_async.test.js
+++ b/test/hello_async.test.js
@@ -21,6 +21,16 @@ test('fail: handles invalid louder value', function(t) {
   module.helloAsync({ louder: 'oops' }, function(err, result) {
     t.ok(err, 'expected error');
     t.ok(err.message.indexOf('option \'louder\' must be a boolean') > -1, 'expected error message');
+    t.equals(err.code, 'EHELLOERROR', 'expected custom error code');
+    t.end();
+  });
+});
+
+test('fail: handles throwing error inside threadpool', function(t) {
+  module.helloAsync({ throw_in_threadpool: true }, function(err, result) {
+    t.ok(err, 'expected error');
+    t.equals(err.message,'error thrown inside threadpool','expected error message');
+    t.equals(err.code, 'EHELLOERROR', 'expected custom error code');
     t.end();
   });
 });


### PR DESCRIPTION
This is not intended to merge, but rather as an example of something to discuss. It shows how to set a custom error code in C++ that can be checked in JS.

Because errors can both happen before entering the threadpool (during the sync code that checks arguments) and inside the threadpool, I needed to apply changes in multiple places. In addition because there is currently no way to trigger an error in the threadpool via JS I added an option that can ask for an error to happen (useful for this demo, not something you'd want in real code).

/cc @mapsam 