### PR TITLE
Implement clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,28 @@
+---
+Checks:          '*'
+WarningsAsErrors: '*'
+HeaderFilterRegex: '\/src\/'
+AnalyzeTemporaryDtors: false
+CheckOptions:    
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,15 @@ matrix:
       env: BUILDTYPE=debug
       node_js: 4
       # Overrides `install` to avoid initializing clang toolchain
-      install: 
-        - ./scripts/format.sh
+      install:
+        # First run the clang-tidy target
+        # This target does not currently return non-zero when problems
+        # are fixed, but rather it fixes automatically. Changed files
+        # will be detected by the format target and will trigger an error
+        - make tidy
+        # Now we run the clang-format script. Any code formatting changes
+        # will trigger the build to fail (idea here is to get us to pay attention
+        # and get in the habit of running these locally before committing)
+        - make format
       # Overrides `script`, no need to run tests
       before_script:

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ coverage:
 tidy:
 	./scripts/clang-tidy.sh
 
+format:
+	./scripts/format.sh
+
 clean:
 	rm -rf lib/binding
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ debug: node_modules
 coverage:
 	./scripts/coverage.sh
 
+tidy:
+	./scripts/clang-tidy.sh
+
 clean:
 	rm -rf lib/binding
 	rm -rf build

--- a/binding.gyp
+++ b/binding.gyp
@@ -53,9 +53,6 @@
         './src/object_sync/hello.cpp',
         './src/object_async/hello_async.cpp'
       ],
-      'include_dirs': [
-        '<!(node -e \'require("nan")\')'
-      ],
       'ldflags': [
         '-Wl,-z,now',
       ],

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+# https://clang.llvm.org/extra/clang-tidy/
+
+# to speed up re-runs, only re-create environment if needed
+if [[ ! -f local.env ]]; then
+    # automatically setup environment
+    ./scripts/setup.sh --config local.env
+fi
+
+# source the environment
+source local.env
+
+PATH_TO_CLANG_TIDY_SCRIPT="$(pwd)/mason_packages/.link/share/run-clang-tidy.py"
+
+# to speed up re-runs, only install clang-tidy if needed
+if [[ ! -f PATH_TO_CLANG_TIDY_SCRIPT ]]; then
+    # The MASON_LLVM_RELEASE variable comes from `local.env`
+    mason install clang-tidy ${MASON_LLVM_RELEASE}
+    # We link the tools to make it easy to know ${PATH_TO_CLANG_TIDY_SCRIPT}
+    mason link clang-tidy ${MASON_LLVM_RELEASE}
+fi
+
+# build the compile_commands.json file if it does not exist
+if [[ ! -f build/compile_commands.json ]]; then
+    # We need to clean otherwise when we make the project
+    # will will not see all the compile commands
+    make clean
+    # Create the build directory to put the compile_commands in
+    # We do this first to ensure it is there to start writing to
+    # immediately (make make not create it right away)
+    mkdir -p build
+    # Run make, pipe the output to the generate_compile_commands.py
+    # and drop them in a place that clang-tidy will automatically find them
+    make | scripts/generate_compile_commands.py > build/compile_commands.json
+fi
+
+# change into the build directory so that clang-tidy can find the files
+# at the right paths (since this is where the actual build happens)
+cd build
+${PATH_TO_CLANG_TIDY_SCRIPT} -fix
+

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -31,6 +31,7 @@ dirty=$(git ls-files --modified src/)
 if [[ $dirty ]]; then
     echo "The following files have been modified:"
     echo $dirty
+    git diff
     exit 1
 else
     exit 0

--- a/scripts/generate_compile_commands.py
+++ b/scripts/generate_compile_commands.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import sys
+import json
+import os
+import re
+
+# Script to generate compile_commands.json based on Makefile output
+# Works by accepting Makefile output from stdin, parsing it, and 
+# turning into json records. These are then printed to stdout.
+# More details on the compile_commands format at:
+# https://clang.llvm.org/docs/JSONCompilationDatabase.html
+#
+# Note: make must be run in verbose mode, e.g. V=1 make or VERBOSE=1 make
+#
+# Usage with node-cpp-skel:
+#
+# make | ./scripts/generate_compile_commands.py > build/compile_commands.json
+
+# These work for node-cpp-skel to detect the files being compiled
+# They may need to be modified if you adapt this to another tool
+matcher = re.compile('^(.*) (.+cpp)\n')
+build_dir = os.path.join(os.getcwd(),"build")
+TOKEN_DENOTING_COMPILED_FILE='NODE_GYP_MODULE_NAME'
+
+def generate():
+    compile_commands = []
+    for line in sys.stdin.readlines():
+        if TOKEN_DENOTING_COMPILED_FILE in line:
+            match = matcher.match(line)
+            compile_commands.append({
+                "directory": build_dir,
+                "command": line.strip(),
+                "file": os.path.normpath(os.path.join(build_dir,match.group(2)))
+            })
+    print json.dumps(compile_commands,indent=4)
+
+if __name__ == '__main__':
+    generate()

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -37,4 +37,11 @@ static void init(v8::Local<v8::Object> target)
     // Include your .hpp file at the top of this file.
 }
 
-NODE_MODULE(module, init)
+// Here we initialize the module (we only do this once)
+// by attaching the init function to the module. This invokes
+// a variety of magic from inside nodejs core that we don't need to
+// worry about, but if you care the details are at https://github.com/nodejs/node/blob/34d1b1144e1af8382dad71c28c8d956ebf709801/src/node.h#L431-L518
+// We mark this NOLINT to avoid the clang-tidy checks
+// warning about code inside nodejs that we don't control and can't
+// directly change to avoid the warning.
+NODE_MODULE(module, init) // NOLINT

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -124,7 +124,7 @@ NAN_METHOD(HelloObject::hello)
      *   - The C++ methods must be static to make them available at startup across
      * the language boundary (JS <-> C++).
      */
-    HelloObject* h = Nan::ObjectWrap::Unwrap<HelloObject>(info.Holder());
+    auto* h = Nan::ObjectWrap::Unwrap<HelloObject>(info.Holder());
 
     // "info" comes from the NAN_METHOD macro, which returns differently
     // according to the version of node

--- a/src/standalone_async/hello_async.cpp
+++ b/src/standalone_async/hello_async.cpp
@@ -50,7 +50,10 @@ std::string do_expensive_work(bool louder)
 
             // AsyncHelloWorker's Execute function will take care of this error
             // and return it to js-world via callback
-            throw std::runtime_error("Uh oh, this should never happen");
+            // Marked NOLINT to avoid clang-tidy cert-err60-cpp error which we cannot
+            // avoid on some linux distros where std::runtime_error is not properly
+            // marked noexcept. Details at https://www.securecoding.cert.org/confluence/display/cplusplus/ERR60-CPP.+Exception+objects+must+be+nothrow+copy+constructible
+            throw std::runtime_error("Uh oh, this should never happen"); // NOLINT
         }
     }
 
@@ -109,7 +112,8 @@ struct AsyncHelloWorker : Nan::AsyncWorker
         v8::Local<v8::Value> argv[argc] = {
             Nan::Null(), Nan::New<v8::String>(result_).ToLocalChecked()};
 
-        callback->Call(argc, argv);
+        // Static cast done here to avoid 'cppcoreguidelines-pro-bounds-array-to-pointer-decay' warning with clang-tidy
+        callback->Call(argc, static_cast<v8::Local<v8::Value>*>(argv));
     }
 
     std::string result_;


### PR DESCRIPTION
This addresses #63 (see that ticket for context).

This PR builds in:

  - `clang-tidy` checks. If `clang-tidy` detects errors travis will fail
  - The `-fix` command is passed so some fixes are automatically done
  - Other warnings need to be noticed and fixed manually

Other notes:

  - Uses a custom python script to convert the Makefile output into `compile_commands.json`
  - Uses clang-tidy from mason, version controlled in the `setup.sh` script - refs #58

/cc @GretaCB for review

/cc @mapbox/directions @mapbox/gl-core - thank you for the examples of clang-tidy usage in OSRM and MBGL - I learned from them in order to apply here ✊ 