### PR TITLE
use latest mason+llvm / make CXX overridable

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,8 +3,8 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-v0.9.0}"
-export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-4.0.0}"
+export MASON_RELEASE="${MASON_RELEASE:-v0.14.1}"
+export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-4.0.1}"
 
 PLATFORM=$(uname | tr A-Z a-z)
 if [[ ${PLATFORM} == 'darwin' ]]; then
@@ -69,7 +69,7 @@ function run() {
     #
 
     echo "export PATH=${llvm_toolchain_dir}/bin:$(pwd)/.mason:$(pwd)/mason_packages/.link/bin:"'${PATH}' > ${config}
-    echo "export CXX=${llvm_toolchain_dir}/bin/clang++" >> ${config}
+    echo "export CXX=${CXX:-${llvm_toolchain_dir}/bin/clang++}" >> ${config}
     echo "export MASON_RELEASE=${MASON_RELEASE}" >> ${config}
     echo "export MASON_LLVM_RELEASE=${MASON_LLVM_RELEASE}" >> ${config}
     # https://github.com/google/sanitizers/wiki/AddressSanitizerAsDso


### PR DESCRIPTION
Closes #58.

In addition allows .travis.yml builds to set `CXX` to use a custom compiler. This is important to be able to set against g++. We don't need to test with g++  for node-cpp-skel, since node-cpp-skel is distributed by binaries. But do need to test hpp-skel with g++ and this allows the `script.sh` used here to exactly match what will be used there  - refs https://github.com/mapbox/hpp-skel/issues/12