### PR TITLE
More to Attach style brace formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,7 @@ BraceWrapping:
   BeforeElse:      true
   IndentBraces:    false
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Custom
+BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 ColumnLimit:     0

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -8,8 +8,7 @@
 // "target" is a magic var that nodejs passes into a module's scope.
 // When you write things to target, they become available to call from
 // Javascript world.
-static void init(v8::Local<v8::Object> target)
-{
+static void init(v8::Local<v8::Object> target) {
 
     // expose hello method
     Nan::SetMethod(target, "hello", standalone::hello);

--- a/src/module_utils.hpp
+++ b/src/module_utils.hpp
@@ -21,8 +21,7 @@ namespace utils {
 *
 */
 inline void CallbackError(std::string message,
-                          v8::Local<v8::Function> callback)
-{
+                          v8::Local<v8::Function> callback) {
     v8::Local<v8::Value> argv[1] = {Nan::Error(message.c_str())};
     Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 1, argv);
 }

--- a/src/object_async/hello_async.hpp
+++ b/src/object_async/hello_async.hpp
@@ -10,8 +10,7 @@ namespace object_async {
  * Also, this class adheres to the rule of Zero because we define no custom
  * destructor or copy constructor
  */
-class HelloObjectAsync : public Nan::ObjectWrap
-{
+class HelloObjectAsync : public Nan::ObjectWrap {
 
   public:
     // initializer

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -32,21 +32,15 @@ namespace object_sync {
 HelloObject::HelloObject(std::string&& name) : name_(std::move(name)) {}
 
 // Triggered from Javascript world when calling "new HelloObject(name)"
-NAN_METHOD(HelloObject::New)
-{
-    if (info.IsConstructCall())
-    {
-        try
-        {
-            if (info.Length() >= 1)
-            {
-                if (info[0]->IsString())
-                {
+NAN_METHOD(HelloObject::New) {
+    if (info.IsConstructCall()) {
+        try {
+            if (info.Length() >= 1) {
+                if (info[0]->IsString()) {
                     // Don't want to risk passing a null string around, which might create unpredictable behavior.
                     Nan::Utf8String utf8_value(info[0]);
                     int len = utf8_value.length();
-                    if (len <= 0)
-                    {
+                    if (len <= 0) {
                         return Nan::ThrowTypeError("arg must be a non-empty string");
                     }
 
@@ -77,36 +71,27 @@ NAN_METHOD(HelloObject::New)
                      */
                     auto* const self = new HelloObject(std::move(name));
                     self->Wrap(info.This()); // Connects C++ object to Javascript object (this)
-                }
-                else
-                {
+                } else {
                     return Nan::ThrowTypeError(
                         "arg must be a string");
                 }
-            }
-            else
-            {
+            } else {
                 return Nan::ThrowTypeError(
                     "must provide string arg");
             }
-        }
-        catch (const std::exception& ex)
-        {
+        } catch (const std::exception& ex) {
             return Nan::ThrowTypeError(ex.what());
         }
 
         info.GetReturnValue().Set(info.This());
-    }
-    else
-    {
+    } else {
         return Nan::ThrowTypeError(
             "Cannot call constructor as function, you need to use 'new' keyword");
     }
 }
 
 // NAN_METHOD is applicable to methods you want to expose to JS world
-NAN_METHOD(HelloObject::hello)
-{
+NAN_METHOD(HelloObject::hello) {
     /**
      * Note: a HandleScope is automatically included inside NAN_METHOD. See the
      * docs at NAN that say:
@@ -135,14 +120,12 @@ NAN_METHOD(HelloObject::hello)
 
 // This is a Singleton, which is a general programming design concept for
 // creating an instance once within a process.
-Nan::Persistent<v8::Function>& HelloObject::create_once()
-{
+Nan::Persistent<v8::Function>& HelloObject::create_once() {
     static Nan::Persistent<v8::Function> init;
     return init;
 }
 
-void HelloObject::Init(v8::Local<v8::Object> target)
-{
+void HelloObject::Init(v8::Local<v8::Object> target) {
     // A handlescope is needed so that v8 objects created in the local memory
     // space (this function in this case)
     // are cleaned up when the function is done running (and the handlescope is

--- a/src/object_sync/hello.hpp
+++ b/src/object_sync/hello.hpp
@@ -8,8 +8,7 @@ namespace object_sync {
      * This is in a header file so we can access it across other .cpp files if necessary
      * Also, this class adheres to the rule of Zero because we define no custom destructor or copy constructor
      */
-class HelloObject : public Nan::ObjectWrap
-{
+class HelloObject : public Nan::ObjectWrap {
 
   public:
     // initializer

--- a/src/standalone/hello.cpp
+++ b/src/standalone/hello.cpp
@@ -19,8 +19,7 @@ namespace standalone {
 // hello is a "standalone function" because it's not a class.
 // If this function was not defined within a namespace, it would be in the
 // global scope.
-NAN_METHOD(hello)
-{
+NAN_METHOD(hello) {
 
     // "info" comes from the NAN_METHOD macro, which returns differently
     // according to the version of node


### PR DESCRIPTION
The idea behind providing `clang-format` support in node-cpp-skel is not as much to enforce a single style but more to make it easy for downstream modules to be able to enforce a consistent style. However it became clear when forward porting dawg-cache (https://github.com/mapbox/dawg-cache/pull/23#issuecomment-334534353) that this style for braces is preferable, so I think we should update skel accordingly:

```c++
if (this) {
  ...
}
```

Rather than:

```C++
if (this)
{
 ...
}
```

/cc @apendleton @GretaCB @mapsam 