### PR TITLE
Enable more default warnings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,6 +20,9 @@
         '-Wconversion',
         '-Wshadow',
         '-Wfloat-equal',
+        '-Wuninitialized',
+        '-Wunreachable-code',
+        '-Wold-style-cast',
         '-Wno-error=unused-variable'
       ]
   },

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,10 +16,11 @@
         '-Wall',
         '-Wextra',
         '-Wconversion',
-        '-pedantic',
-        '-Wsign-compare',
+        '-pedantic-errors',
         '-Wconversion',
-        '-Wshadow'
+        '-Wshadow',
+        '-Wfloat-equal',
+        '-Wno-error=unused-variable'
       ]
   },
   # `targets` is a list of targets for gyp to run.

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,6 +9,17 @@
       'system_includes': [
         "-isystem <(module_root_dir)/<!(node -e \"require('nan')\")",
         "-isystem <(module_root_dir)/mason_packages/.link/include/"
+      ],
+      # Flags we pass to the compiler to ensure the compiler
+      # warns us about potentially buggy or dangerous code
+      'compiler_checks': [
+        '-Wall',
+        '-Wextra',
+        '-Wconversion',
+        '-pedantic',
+        '-Wsign-compare',
+        '-Wconversion',
+        '-Wshadow'
       ]
   },
   # `targets` is a list of targets for gyp to run.
@@ -64,15 +75,17 @@
             }
         }]
       ],
-      'cflags': [
-          '<@(system_includes)'
+      'cflags_cc': [
+          '<@(system_includes)',
+          '<@(compiler_checks)'
       ],
       'xcode_settings': {
         'OTHER_LDFLAGS':[
           '-Wl,-bind_at_load'
         ],
         'OTHER_CPLUSPLUSFLAGS': [
-            '<@(system_includes)'
+            '<@(system_includes)',
+            '<@(compiler_checks)'
         ],
         'GCC_ENABLE_CPP_RTTI': 'YES',
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',

--- a/src/object_async/hello_async.cpp
+++ b/src/object_async/hello_async.cpp
@@ -154,8 +154,8 @@ struct AsyncHelloWorker : Nan::AsyncWorker // NOLINT to disable cppcoreguideline
     AsyncHelloWorker& operator=(AsyncHelloWorker const&) = delete;
 
     AsyncHelloWorker(bool louder, const std::string* name,
-                     Nan::Callback* callback)
-        : Base(callback), result_{""}, louder_{louder}, name_{name} {}
+                     Nan::Callback* cb)
+        : Base(cb), result_{""}, louder_{louder}, name_{name} {}
 
     // The Execute() function is getting called when the worker starts to run.
     // - You only have access to member variables stored in this worker.

--- a/src/object_async/hello_async.cpp
+++ b/src/object_async/hello_async.cpp
@@ -67,7 +67,7 @@ NAN_METHOD(HelloObjectAsync::New) {
                     * Also, providing the length allows the std::string constructor to avoid calculating the length internally
                     * and should be faster since it skips an operation.
                     */
-                    std::string name(*utf8_value, len);
+                    std::string name(*utf8_value, static_cast<std::size_t>(len));
 
                     /** 
                     * This line is where HelloObjectAsync takes ownership of "name" with the use of move semantics.

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -53,7 +53,7 @@ NAN_METHOD(HelloObject::New) {
                      * Also, providing the length allows the std::string constructor to avoid calculating the length internally
                      * and should be faster since it skips an operation.
                      */
-                    std::string name(*utf8_value, len);
+                    std::string name(*utf8_value, static_cast<std::size_t>(len));
 
                     /** 
                      * This line is where HelloObjectAsync takes ownership of "name" with the use of move semantics.

--- a/src/standalone_async/hello_async.cpp
+++ b/src/standalone_async/hello_async.cpp
@@ -71,8 +71,8 @@ std::string do_expensive_work(bool louder) {
 struct AsyncHelloWorker : Nan::AsyncWorker {
     using Base = Nan::AsyncWorker;
 
-    AsyncHelloWorker(bool louder, Nan::Callback* callback)
-        : Base(callback), result_{""}, louder_{louder} {}
+    AsyncHelloWorker(bool louder, Nan::Callback* cb)
+        : Base(cb), result_{""}, louder_{louder} {}
 
     // The Execute() function is getting called when the worker starts to run.
     // - You only have access to member variables stored in this worker.


### PR DESCRIPTION
We should have a more aggressive set of default warnings we enable.

refs mapbox/cpp#37

This brings node-cpp-skel in line with hpp-skel: https://github.com/mapbox/hpp-skel/blob/0af4ae29ec83fe12db20963fcd0855dbe7708a57/CMakeLists.txt#L22

/cc @GretaCB @mapsam 