### PR TITLE
add glossary link for inline note

### DIFF
--- a/src/module_utils.hpp
+++ b/src/module_utils.hpp
@@ -14,10 +14,9 @@ namespace utils {
 *
 *
 * "inline" is important here as well. See for more contex:
+* - https://github.com/mapbox/cpp/blob/master/glossary.md#inline-keyword
 * - https://github.com/mapbox/node-cpp-skel/pull/52#discussion_r126847394 for
 * context
-* - https://github.com/mapbox/cpp/pull/29 ...eventually point this to glossary
-* when it merges
 *
 */
 inline void CallbackError(std::string message,


### PR DESCRIPTION
The code comments said to add a glossary link for inlining when they exist .. they do now! This updates the comment.

cc @GretaCB @springmeyer 