### PR TITLE
make sanitize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ tidy:
 format:
 	./scripts/clang-format.sh
 
+sanitize:
+	./scripts/sanitize.sh
+
 clean:
 	rm -rf lib/binding
 	rm -rf build

--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ Note: by default the build errors on compiler warnings. To disable this do:
 WERROR=false make
 ```
 
-Enable additional sanitizers to catch hard-to-find bugs, for example:
+Run tests locally with compile flags enabled to catch hard-to-find bugs (see [this PR](https://github.com/mapbox/node-cpp-skel/pull/85) for more info):
 
 ```shell
 make sanitize
 ```
+
+The sanitizers [are part of the compiler](https://github.com/mapbox/cpp/blob/master/glossary.md#sanitizers) are also run in a specific job on Travis.
 
 # Add Custom Code
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,7 @@ WERROR=false make
 Enable additional sanitizers to catch hard-to-find bugs, for example:
 
 ```shell
-export LDFLAGS="-fsanitize=address,undefined,integer"
-export CXXFLAGS="-fsanitize=address,undefined,integer"
-
-make
+make sanitize
 ```
 
 # Add Custom Code

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Run tests locally with compile flags enabled to catch hard-to-find bugs (see [th
 make sanitize
 ```
 
-The sanitizers [are part of the compiler](https://github.com/mapbox/cpp/blob/master/glossary.md#sanitizers) are also run in a specific job on Travis.
+The sanitizers [are part of the compiler](https://github.com/mapbox/cpp/blob/master/glossary.md#sanitizers) and are also run in a specific job on Travis.
 
 # Add Custom Code
 

--- a/scripts/sanitize.sh
+++ b/scripts/sanitize.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+: '
+
+Rebuilds the code with the sanitizers and runs the tests
+
+'
+ # Set up the environment by installing mason and clang++
+ # See https://github.com/mapbox/node-cpp-skel/blob/master/docs/extended-tour.md#configuration-files
+./scripts/setup.sh --config local.env
+source local.env
+make clean
+export CXXFLAGS="${MASON_SANITIZE_CXXFLAGS} ${CXXFLAGS:-}"
+export LDFLAGS="${MASON_SANITIZE_LDFLAGS} ${LDFLAGS:-}"
+make debug
+export ASAN_OPTIONS=fast_unwind_on_malloc=0:${ASAN_OPTIONS}
+if [[ $(uname -s) == 'Darwin' ]]; then
+    # NOTE: we must call node directly here rather than `npm test`
+    # because OS X blocks `DYLD_INSERT_LIBRARIES` being inherited by sub shells
+    # If this is not done right we'll see
+    #   ==18464==ERROR: Interceptors are not working. This may be because AddressSanitizer is loaded too late (e.g. via dlopen).
+    #
+    DYLD_INSERT_LIBRARIES=${MASON_LLVM_RT_PRELOAD} \
+      node test/*test.js
+else
+    LD_PRELOAD=${MASON_LLVM_RT_PRELOAD} \
+      npm test
+fi
+

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,8 +3,8 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-v0.14.1}"
-export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-4.0.1}"
+export MASON_RELEASE="${MASON_RELEASE:-eeba3b5}"
+export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.0}"
 
 PLATFORM=$(uname | tr A-Z a-z)
 if [[ ${PLATFORM} == 'darwin' ]]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -89,8 +89,8 @@ function run() {
     echo "export MSAN_SYMBOLIZER_PATH=${llvm_toolchain_dir}/bin/llvm-symbolizer" >> ${config}
     echo "export UBSAN_OPTIONS=print_stacktrace=1" >> ${config}
     echo "export LSAN_OPTIONS=suppressions=${SUPPRESSION_FILE}" >> ${config}
-    echo "export ASAN_OPTIONS=symbolize=1:abort_on_error=1:detect_container_overflow=1:check_initialization_order=1:detect_stack_use_after_return=1" >> ${config}
-    echo 'export MASON_SANITIZE="-fsanitize=address,undefined,integer -fno-sanitize=vptr,function"' >> ${config}
+    echo "export ASAN_OPTIONS=detect_leaks=1:symbolize=1:abort_on_error=1:detect_container_overflow=1:check_initialization_order=1:detect_stack_use_after_return=1" >> ${config}
+    echo 'export MASON_SANITIZE="-fsanitize=address,undefined,integer,leak -fno-sanitize=vptr,function"' >> ${config}
     echo 'export MASON_SANITIZE_CXXFLAGS="${MASON_SANITIZE} -fno-sanitize=vptr,function -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-common"' >> ${config}
     echo 'export MASON_SANITIZE_LDFLAGS="${MASON_SANITIZE}"' >> ${config}
 

--- a/src/module_utils.hpp
+++ b/src/module_utils.hpp
@@ -24,4 +24,4 @@ inline void CallbackError(std::string message,
     v8::Local<v8::Value> argv[1] = {Nan::Error(message.c_str())};
     Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, 1, argv);
 }
-}
+} // namespace utils

--- a/src/object_async/hello_async.hpp
+++ b/src/object_async/hello_async.hpp
@@ -33,4 +33,4 @@ class HelloObjectAsync : public Nan::ObjectWrap {
     // specific to each instance of the class
     std::string name_;
 };
-}
+} // namespace object_async

--- a/src/object_sync/hello.hpp
+++ b/src/object_sync/hello.hpp
@@ -31,4 +31,4 @@ class HelloObject : public Nan::ObjectWrap {
     // specific to each instance of the class
     std::string name_;
 };
-}
+} // namespace object_sync

--- a/src/standalone/hello.hpp
+++ b/src/standalone/hello.hpp
@@ -33,4 +33,4 @@ namespace standalone {
 // hello, custom sync method tied to module.cpp
 // method's logic lives in hello.cpp
 NAN_METHOD(hello);
-}
+} // namespace standalone

--- a/src/standalone_async/hello_async.hpp
+++ b/src/standalone_async/hello_async.hpp
@@ -32,4 +32,4 @@ namespace standalone_async {
 // hello, custom sync method tied to module.cpp
 // method's logic lives in hello.cpp
 NAN_METHOD(helloAsync);
-}
+} // namespace standalone_async


### PR DESCRIPTION
Running with the clang++ sanitizers locally should be easy. It is now. Just run:

```
make sanitize
```

Which will build with all key sanitizers enabled and run the tests. This should work on both Linux and OS X. It handles these various gochas which otherwise make setting up the sanitizers locally a difficult and error prone task:

 - Apple clang++ from xcode does not support the sanitizers
   - This uses clang++ 5.x from mason which supports them (leaks as of >= 5.x)
- The Leak Sanitizer is not enabled by default on OS X
   - It sets `ASAN_OPTIONS=detect_leaks:1` to enable leak checking on OS X
- For the sanitizers to work with nodejs that is not compiled with them they need to be loaded at runtime
   - This loads the asan libraries at runtime, and handles cross-platform gochas including:
      - The library paths are different on OS X and Linux
      - The command to preload libraries is also different `LD_PRELOAD` vs `DYLD_INSERT_LIBRARIES`
      - The `npm test` command on OS X will fail since `DYLD_INSERT_LIBRARIES` cannot be inherited by shells so we call `node test/*.test.js` directly to workaround this limitation
- For the sanitzer error reports to contain line numbers we need to:
   - Build in debug mode
   - Tell clang++ where the  `llvm-symbolizer` is located with the `ASAN_SYMBOLIZER_PATH` (done in ./scripts/setup.sh)

Builds upon #75.

/cc @GretaCB