### PR TITLE
Add liftoff script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# 11/17/2017
+
+* Add liftoff script, setup docs, and more contributing details per https://github.com/mapbox/node-cpp-skel/pull/87
+
+# 10/31/2017
+
+* Add [sanitzer flag doc](https://github.com/mapbox/node-cpp-skel/pull/84)
+* Add [sanitizer script](hhttps://github.com/mapbox/node-cpp-skel/pull/85) and enable [leak sanitizer](https://github.com/mapbox/node-cpp-skel/commit/725601e4c7df6cb8477a128f018fb064a9f6f9aa)
+* 
+
+# 10/20/2017
+
+* Add [code of conduct](https://github.com/mapbox/node-cpp-skel/pull/82)
+* Add [CC0 license](https://github.com/mapbox/node-cpp-skel/pull/82)
+* Point to [cpp glossary](https://github.com/mapbox/node-cpp-skel/pull/83)
+
+# 10/12/2017
+
+* Update compiler flags per best practices per https://github.com/mapbox/cpp/issues/37
+  - https://github.com/mapbox/node-cpp-skel/pull/80
+  - https://github.com/mapbox/node-cpp-skel/pull/78
+  - https://github.com/mapbox/node-cpp-skel/pull/77
+
+# 09/10/2017
+
+* [Sanitize update](https://github.com/mapbox/node-cpp-skel/pull/74)
+
+# 08/24/2017
+
+* Clang tidy updates
+  - https://github.com/mapbox/node-cpp-skel/pull/68
+  - https://github.com/mapbox/node-cpp-skel/issues/65
+  - https://github.com/mapbox/node-cpp-skel/pull/64
+  - https://github.com/mapbox/node-cpp-skel/pull/66
+
+# 08/15/2017
+
+* Add [bench scripts](https://github.com/mapbox/node-cpp-skel/pull/61) for async examples
+
+# 08/09/2017
+
+* Add comments about "new" allocation
+
+# 08/08/2017
+
+* Add [clang-format](https://github.com/mapbox/node-cpp-skel/pull/56)
+
+# 08/04/2017
+
+* Use Nan's safer and high performance `Nan::Utf8String` when accepting string args per https://github.com/mapbox/node-cpp-skel/pull/55
+
+# 08/3/2017
+
+* Reorganize [documentation](https://github.com/mapbox/node-cpp-skel/pull/53)
+
+# 07/21/2017
+
+* Add [object_async example](https://github.com/mapbox/node-cpp-skel/pull/52)
+
+# 07/11/2017
+
+* Add [build docs](https://github.com/mapbox/node-cpp-skel/pull/51)
+
+* It begins

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,16 @@
-# Code Formatting
+# Contributing
+
+Thanks for getting involved and contributing to the skel :tada: Below are a few things to setup when submitting a PR.
+
+## Code comments
+
+If adding new code, be sure to include relevant code comments. Code comments are a great way for others to learn from your code. This is especially true within the skeleton, since it is made for learning.
+
+## Update Documentation
+
+Be sure to update any documentation relevant to your change. This includes updating the [CHANGELOG.md](https://github.com/mapbox/node-cpp-skel/blob/master/CHANGELOG.md).
+
+## Code Formatting
 
 We use [this script](/scripts/format.sh#L20) to install a consistent version of [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) to format the code base. The format is automatically checked via a Travis CI build as well. Run the following script locally to ensure formatting is ready to merge:
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,37 @@ The sanitizers [are part of the compiler](https://github.com/mapbox/cpp/blob/mas
 
 # Add Custom Code
 
-`node-cpp-skel` was designed to make adding custom code simple and scalable, to form to whatever usecase you may need. Here's how:
+Depending on your usecase, there are a variety of ways to start using this skeleton for your project.
+
+### Setup new project
+Easily use this skeleton as a starting off point for a _new_ custom project:
+
+```
+# Clone node-cpp-skel locally
+
+git clone git@github.com:mapbox/node-cpp-skel.git
+cd node-cpp-skel/
+
+# Create your new repo on GitHub and have the remote repo url handy for liftoff
+# Then run the liftoff script from within your local node-cpp-skel root directory.
+#
+# This will:
+# - prompt you for the new name of your project and the new remote repo url
+# - automatically create a new directory for your new project repo
+# - create a new branch called "node-cpp-skel-port" within your new repo directory
+# - add, commit, and push that branch to your new repo
+
+./scripts/liftoff.sh
+
+```
+
+### Add your code
+Once your project has ported node-cpp-skel, follow these steps to integrate your own code:
 
 - Create a dir in `./src` to hold your custom code. See the example code within `/src` for reference.
 - Add your new method or class to `./src/module.cpp`, and `#include` it at the top
 - Add your new file-to-be-compiled to the list of target sources in `./binding.gyp`
+- Run `make` and see what surprises await on your new journey
 
 # Code coverage
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Once your project has ported node-cpp-skel, follow these steps to integrate your
 - Create a dir in `./src` to hold your custom code. See the example code within `/src` for reference.
 - Add your new method or class to `./src/module.cpp`, and `#include` it at the top
 - Add your new file-to-be-compiled to the list of target sources in `./binding.gyp`
-- Run `make` and see what surprises await on your new journey
+- Run `make` and see what surprises await on your new journey :boat:
 
 # Code coverage
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -20,6 +20,6 @@ This will run a bunch of calls to the module's `helloAsync()` function. You can 
 The bench tests and async functions that come with `node-cpp-skel` out of the box demonstrate this behaviour:
 - An async function that is CPU intensive and takes a while to finish (expensive creation and querying of a `std::map` and string comparisons). 
 - Worker threads are busy doing a lot of work, and the main loop is relatively idle. Depending on how many threads (concurrency) you enable, you may see your CPU% sky-rocket and your cores max out. Yeaahhh!!!
-- If you bump up `--iterations` to 500 and profile in Activity Monitor.app, you'll see the main loop is idle as expected since the threads are doing all the work. You'll also see the threads busy doing work in AsyncHelloWorker roughly 99% of the time :tada:
+- If you bump up `--iterations` to 500 and [profile in Activity Monitor.app](https://github.com/springmeyer/profiling-guide#activity-monitorapp-on-os-x), you'll see the main loop is idle as expected since the threads are doing all the work. You'll also see the threads busy doing work in AsyncHelloWorker roughly 99% of the time :tada:
 
 ![](https://user-images.githubusercontent.com/1209162/29333300-e7c483e2-81c8-11e7-8253-1beb12173841.png)

--- a/scripts/liftoff.sh
+++ b/scripts/liftoff.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# First create new repo on GitHub and copy the SSH repo url
+# Then run "./scripts/liftoff.sh" from within your local node-cpp-skel root directory
+# and will create your new local project repo side by side with node-cpp-skel directory
+
+echo "What is the name of your new project? "
+read name
+echo "What is the remote repo url for your new project? "
+read url
+
+mkdir ../$name
+cp -R ../node-cpp-skel/. ../$name/
+cd ../$name/
+rm -rf .git
+git init
+
+git checkout -b node-cpp-skel-port
+git add .
+git commit -m "Port from node-cpp-skel"
+git remote add origin $url
+git push -u origin node-cpp-skel-port
+
+# Perhaps useful for fresh start, also check out https://github.com/mapbox/node-cpp-skel#add-custom-code
+# cp /dev/null CHANGELOG.md
+# cp /dev/null README.md

--- a/scripts/liftoff.sh
+++ b/scripts/liftoff.sh
@@ -4,7 +4,7 @@ set -eu
 
 # First create new repo on GitHub and copy the SSH repo url
 # Then run "./scripts/liftoff.sh" from within your local node-cpp-skel root directory
-# and will create your new local project repo side by side with node-cpp-skel directory
+# and it will create your new local project repo side by side with node-cpp-skel directory
 
 echo "What is the name of your new project? "
 read name


### PR DESCRIPTION
### Liftoff: Phase 1
Per https://github.com/mapbox/hpp-skel/issues/22 and modeled from [hpp-skel's liftoff script]()https://github.com/mapbox/hpp-skel/pull/29. 

`node-cpp-skel` is a bit more complex than `hpp-skel`, so the customization will look different. Therefore, this script is mainly intended as a way to copy `node-cpp-skel` to a brand new github repo via a port branch. Further manual customization/cleanup is required depending on intended usecase.

This is super rough.

### Next Actions
- [x] Update changelog

cc @mapbox/core-tech 