### PR TITLE
Fix sanitize testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ matrix:
     - os: linux
       env: BUILDTYPE=debug TOOLSET=asan
       node_js: 4
+      sudo: required
       # Overrides `install` to set up custom asan flags
       install:
         - ./scripts/setup.sh --config local.env

--- a/scripts/sanitize.sh
+++ b/scripts/sanitize.sh
@@ -24,7 +24,7 @@ if [[ $(uname -s) == 'Darwin' ]]; then
     #   ==18464==ERROR: Interceptors are not working. This may be because AddressSanitizer is loaded too late (e.g. via dlopen).
     #
     DYLD_INSERT_LIBRARIES=${MASON_LLVM_RT_PRELOAD} \
-      node test/*test.js
+      node node_modules/.bin/tape test/*test.js
 else
     LD_PRELOAD=${MASON_LLVM_RT_PRELOAD} \
       npm test


### PR DESCRIPTION
@GretaCB noticed a problem whereby `make sanitize` was only testing one test rather then all of them. The problem was a bug in my original implementation that assumed that `node test/*test.js` would run all the `tape` tests, when in fact we need to do `tape test/*test.js` to run them all (because only `tape` knows how to loop through each). The trick to keep the sanitizers working on OS X (and avoid the problem of losing the `DYLD_INSERT_LIBRARIES` value) is to run tape using node directly.