### PR TITLE
Upgrade to llvm 6 toolchain

### DIFF
--- a/mason-versions.ini
+++ b/mason-versions.ini
@@ -1,8 +1,8 @@
 [headers]
 protozero=1.6.1
 [compiled]
-clang++=5.0.1
-clang-tidy=5.0.1
-clang-format=5.0.1
-llvm-cov=5.0.1
+clang++=6.0.0
+clang-tidy=6.0.0
+clang-format=6.0.0
+llvm-cov=6.0.0
 binutils=2.30


### PR DESCRIPTION
@allieoop packaged the freshly released LLVM 6.0.0 toolchain in mason. This updates node-cpp-skel to start using (and testing) it. If this works then all downstream deps will be encouraged to update too (by forward porting to the latest skel framework).

This change specifically:

 - Uses new packages for llvm 6.0.0 (and sub-packages) mapbox/mason#600 (@allieoop)
 - Uses bundled pyyaml so that should no longer be needed when using >= llvm 6 (refs mapbox/node-cpp-skel#106)

/cc @mapbox/core-tech 