### PR TITLE
Fix build type variable in osx debug build matrix entry.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
     # osx publishable node v6/debug
     - os: osx
       osx_image: xcode9.2
-      env: BUILDTYPE=release
+      env: BUILDTYPE=debug
       node_js: 6
     # linux sanitizer build node v6/debug
     - os: linux


### PR DESCRIPTION
The `BUILDTYPE=` value was incorrect for OSX debug builds - this PR fixes it.  Without this change, there are two identical entries for OSX in the build matrix.