### PR TITLE
Use explicit python version to match script syntax.

### DIFF
--- a/scripts/generate_compile_commands.py
+++ b/scripts/generate_compile_commands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import json


### PR DESCRIPTION
The `generate_compile_commands.py` script uses Python2 syntax, but has `#!/usr/bin/env python` at the shebang.  Systems could alias `python` to either Python 2 or 3, so sometimes this script will fail with syntax errors if the user's system has the wrong default.

This change makes the shebang line explicit about which python version is used.  It might still fail if the user doesn't have python2, but the error message will be a bit clearer, and it won't be for unexpected syntax errors.