### PR TITLE
Remove binutils install in `sanitize.sh`

### DIFF
--- a/scripts/sanitize.sh
+++ b/scripts/sanitize.sh
@@ -19,11 +19,6 @@ if [[ $(uname -s) == 'Darwin' ]]; then
     SHARED_LIB_EXT=.dylib
 fi
 
-if [[ $(uname -s) == 'Linux' ]]; then
-    ./node_modules/.bin/mason-js install binutils=2.30 --type=compiled
-    ./node_modules/.bin/mason-js link binutils=2.30 --type=compiled
-    export PATH=$(pwd)/mason_packages/.link/bin:${PATH}
-fi
 export MASON_LLVM_RT_PRELOAD=$(pwd)/$(ls mason_packages/.link/lib/clang/*/lib/*/libclang_rt.asan*${SHARED_LIB_EXT})
 SUPPRESSION_FILE="/tmp/leak_suppressions.txt"
 echo "leak:__strdup" > ${SUPPRESSION_FILE}


### PR DESCRIPTION
Binutils is actually now installed in the `mason-versions.ini` so this code is no longer needed. Overall binutiles is needed on linux for LTO support. And there appears to be no harm installing it (and not using it) on OS X.