### PR TITLE
Improve the clang-tidy script

### DIFF
--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -31,7 +31,7 @@ if [[ ! -f build/compile_commands.json ]]; then
     # Run make, pipe the output to the generate_compile_commands.py
     # and drop them in a place that clang-tidy will automatically find them
     RESULT=0
-    make > /tmp/make-node-cpp-skel-build-output.txt || RESULT=$?
+    make | tee /tmp/make-node-cpp-skel-build-output.txt || RESULT=$?
     if [[ ${RESULT} != 0 ]]; then
         echo "Build failed, could not generate compile commands for clang-tidy, aborting!"
         exit ${RESULT}

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -30,7 +30,15 @@ if [[ ! -f build/compile_commands.json ]]; then
     mkdir -p build
     # Run make, pipe the output to the generate_compile_commands.py
     # and drop them in a place that clang-tidy will automatically find them
-    make | scripts/generate_compile_commands.py > build/compile_commands.json
+    RESULT=0
+    make > /tmp/make-node-cpp-skel-build-output.txt || RESULT=$?
+    if [[ ${RESULT} != 0 ]]; then
+        echo "Build failed, could not generate compile commands for clang-tidy, aborting!"
+        exit ${RESULT}
+    else
+        cat /tmp/make-node-cpp-skel-build-output.txt | scripts/generate_compile_commands.py > build/compile_commands.json
+    fi
+
 fi
 
 # change into the build directory so that clang-tidy can find the files


### PR DESCRIPTION
This fixes a longstanding issue in the `scripts/clang-tidy.sh` script. Previously if the build failed it would leave behind an empty `build/compile_commands.json`. Then - when you went to run the `tidy` target again - the script logic would see that `build/compile_commands.json` existed and 
 would avoid running the build again, leading clang-tidy to spuriously report nothing.

This change improves the script to avoid the possibility that it will write an empty `build/compile_commands.json`

Context: The `scripts/generate_compile_commands.py` is needed to reformat the build out into this specific format (https://clang.llvm.org/docs/JSONCompilationDatabase.html). Some build systems can do this automatically (like cmake https://cmake.org/cmake/help/v3.5/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html) but here we use gyp, which cannot. So the `scripts/generate_compile_commands.py` is my attempt to bolt this functionality onto gyp.

/cc @allieoop for final PR. This PR is a subset created via https://github.com/mapbox/node-cpp-skel/pull/118/files#diff-297d66ab0c294f76d1a7ab83006a7383