### PR TITLE
Remove -std=gnu++1y

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -12,7 +12,7 @@
       # More details at https://github.com/mapbox/mason/issues/319
       '-D_GLIBCXX_USE_CXX11_ABI=0'
     ],
-    'cflags_cc!': ['-std=gnu++0x','-fno-rtti', '-fno-exceptions'],
+    'cflags_cc!': ['-std=gnu++0x','-std=gnu++1y', '-fno-rtti', '-fno-exceptions'],
     'configurations': {
       'Debug': {
         'defines!': [


### PR DESCRIPTION
Node v10 starts adding `-std=gnu++1y` to the inherited flags from node.js https://github.com/nodejs/node/blob/7bdc69426772a2915bc348f491aa7eaa44d422df/common.gypi#L348. This is problematic if we actually want to support `c++14` for the compile of the addon, which we do. So, this fix will remove the node.js flag to avoid sending both flags to the compiler - refs https://github.com/mapbox/vtquery/issues/100