### PR TITLE
Return Buffer object with handoff from unique ptr string

### DIFF
--- a/src/module_utils.hpp
+++ b/src/module_utils.hpp
@@ -24,4 +24,21 @@ inline void CallbackError(std::string message, v8::Local<v8::Function> func) {
     v8::Local<v8::Value> argv[1] = {Nan::Error(message.c_str())};
     Nan::Call(cb, 1, argv);
 }
+
+inline Nan::MaybeLocal<v8::Object> NewBufferFrom(std::unique_ptr<std::string> && ptr)
+{
+    Nan::MaybeLocal<v8::Object> res = Nan::NewBuffer(
+            &(*ptr)[0],
+            ptr->size(),
+            [](char*, void* hint) {
+                delete static_cast<std::string*>(hint);
+            },
+            ptr.get());
+    if (!res.IsEmpty())
+    {
+        ptr.release();
+    }
+    return res;
+}
+
 } // namespace utils

--- a/src/module_utils.hpp
+++ b/src/module_utils.hpp
@@ -1,5 +1,7 @@
 #pragma once
+#include <memory>
 #include <nan.h>
+#include <string>
 
 namespace utils {
 
@@ -25,17 +27,15 @@ inline void CallbackError(std::string message, v8::Local<v8::Function> func) {
     Nan::Call(cb, 1, argv);
 }
 
-inline Nan::MaybeLocal<v8::Object> NewBufferFrom(std::unique_ptr<std::string> && ptr)
-{
+inline Nan::MaybeLocal<v8::Object> NewBufferFrom(std::unique_ptr<std::string>&& ptr) {
     Nan::MaybeLocal<v8::Object> res = Nan::NewBuffer(
-            &(*ptr)[0],
-            ptr->size(),
-            [](char*, void* hint) {
-                delete static_cast<std::string*>(hint);
-            },
-            ptr.get());
-    if (!res.IsEmpty())
-    {
+        &(*ptr)[0],
+        ptr->size(),
+        [](char*, void* hint) {
+            delete static_cast<std::string*>(hint);
+        },
+        ptr.get());
+    if (!res.IsEmpty()) {
         ptr.release();
     }
     return res;

--- a/src/object_async/hello_async.cpp
+++ b/src/object_async/hello_async.cpp
@@ -160,7 +160,7 @@ struct AsyncHelloWorker : Nan::AsyncWorker // NOLINT to disable cppcoreguideline
                      bool buffer,
                      const std::string* name,
                      Nan::Callback* cb)
-        : Base(cb, "skel:object-async-worker"), 
+        : Base(cb, "skel:object-async-worker"),
           louder_(louder),
           buffer_(buffer),
           name_(name) {}

--- a/src/object_async/hello_async.cpp
+++ b/src/object_async/hello_async.cpp
@@ -161,6 +161,7 @@ struct AsyncHelloWorker : Nan::AsyncWorker // NOLINT to disable cppcoreguideline
                      const std::string* name,
                      Nan::Callback* cb)
         : Base(cb, "skel:object-async-worker"),
+          result_(),
           louder_(louder),
           buffer_(buffer),
           name_(name) {}

--- a/src/object_async/hello_async.cpp
+++ b/src/object_async/hello_async.cpp
@@ -22,6 +22,7 @@
  * @memberof HelloObjectAsync
  * @param {Object} args - different ways to alter the string
  * @param {boolean} args.louder - adds exclamation points to the string
+ * @param {buffer} args.buffer - returns object as a node buffer rather then string
  * @param {Function} callback - from whence the hello comes, returns a string
  * @returns {String}
  * @example

--- a/src/object_sync/hello.cpp
+++ b/src/object_sync/hello.cpp
@@ -31,7 +31,7 @@ namespace object_sync {
 // Custom constructor, assigns custom name passed in from Javascript world.
 // This constructor uses member init list via the semicolon, aka "direct initialization"
 // which is more efficient than using assignment operators.
-HelloObject::HelloObject(std::string&& name) : name_(std::move(name)) {}
+HelloObject::HelloObject(std::string&& name) : name_(name) {}
 
 // Triggered from Javascript world when calling "new HelloObject(name)"
 NAN_METHOD(HelloObject::New) {

--- a/src/standalone_async/hello_async.cpp
+++ b/src/standalone_async/hello_async.cpp
@@ -73,7 +73,7 @@ struct AsyncHelloWorker : Nan::AsyncWorker {
     using Base = Nan::AsyncWorker;
 
     AsyncHelloWorker(bool louder, bool buffer, Nan::Callback* cb)
-        : Base(cb, "skel:standalone-async-worker"), louder_(louder), buffer_(buffer) {}
+        : Base(cb, "skel:standalone-async-worker"), result_(), louder_(louder), buffer_(buffer) {}
 
     // The Execute() function is getting called when the worker starts to run.
     // - You only have access to member variables stored in this worker.

--- a/src/standalone_async/hello_async.cpp
+++ b/src/standalone_async/hello_async.cpp
@@ -12,6 +12,7 @@
  * @name helloAsync
  * @param {Object} args - different ways to alter the string
  * @param {boolean} args.louder - adds exclamation points to the string
+ * @param {boolean} args.buffer - returns value as a node buffer rather than a string
  * @param {Function} callback - from whence the hello comes, returns a string
  * @returns {string}
  * @example

--- a/test/hello_async.test.js
+++ b/test/hello_async.test.js
@@ -17,10 +17,28 @@ test('success: prints regular busy world', function(t) {
   });
 });
 
+test('success: buffer regular busy world', function(t) {
+  module.helloAsync({ buffer: true }, function(err, result) {
+    if (err) throw err;
+    t.equal(result.length, 44);
+    t.equal(typeof(result), 'object');
+    t.equal(result.toString(), '...threads are busy async bees...hello world');
+    t.end();
+  });
+});
+
 test('error: handles invalid louder value', function(t) {
   module.helloAsync({ louder: 'oops' }, function(err, result) {
     t.ok(err, 'expected error');
     t.ok(err.message.indexOf('option \'louder\' must be a boolean') > -1, 'expected error message');
+    t.end();
+  });
+});
+
+test('error: handles invalid buffer value', function(t) {
+  module.helloAsync({ buffer: 'oops' }, function(err, result) {
+    t.ok(err, 'expected error');
+    t.ok(err.message.indexOf('option \'buffer\' must be a boolean') > -1, 'expected error message');
     t.end();
   });
 });

--- a/test/hello_object_async.test.js
+++ b/test/hello_object_async.test.js
@@ -19,6 +19,17 @@ test('success: prints loud busy world', function(t) {
   });
 });
 
+test('success: return buffer busy world', function(t) {
+  var H = new module.HelloObjectAsync('world');
+  H.helloAsync({ buffer: true }, function(err, result) {
+    if (err) throw err;
+    t.equal(result.length, 44);
+    t.equal(typeof(result), 'object');
+    t.equal(result.toString(), '...threads are busy async bees...hello world');
+    t.end();
+  });
+});
+
 test('error: throws when passing empty string', function(t) {
   try {
     var H = new module.HelloObjectAsync('');
@@ -54,6 +65,15 @@ test('error: handles invalid louder value', function(t) {
   H.helloAsync({ louder: 'oops' }, function(err, result) {
     t.ok(err, 'expected error');
     t.ok(err.message.indexOf('option \'louder\' must be a boolean') > -1, 'expected error message');
+    t.end();
+  });
+});
+
+test('error: handles invalid buffer value', function(t) {
+  var H = new module.HelloObjectAsync('world');
+  H.helloAsync({ buffer: 'oops' }, function(err, result) {
+    t.ok(err, 'expected error');
+    t.ok(err.message.indexOf('option \'buffer\' must be a boolean') > -1, 'expected error message');
     t.end();
   });
 });


### PR DESCRIPTION
Added the ability to return the string as a buffer object instead for async methods with this buffer object handing off the result string rather then copying. 

Related issue: #69 

/cc @springmeyer @GretaCB 
