### PR TITLE
stop bundling node-pre-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "scripts": {
     "test": "tape test/*.test.js",
-    "prepublishOnly": "npm ls",
     "install": "node-pre-gyp install --fallback-to-build",
     "docs": "documentation build src/standalone_async/*.cpp src/standalone/*.cpp src/object_sync/*.cpp src/object_async/*.cpp --polyglot -f md -o API.md"
   },
@@ -21,9 +20,6 @@
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.0"
   },
-  "bundledDependencies": [
-    "node-pre-gyp"
-  ],
   "devDependencies": {
     "aws-sdk": "^2.4.7",
     "tape": "^4.5.1",


### PR DESCRIPTION
We no longer want to bundle node-pre-gyp. Bundling has the drawbacks of:

 - in a downstream module you don't get any security updates for node-pre-gyp dependencies, or node-pre-gyp yourself until you re-tag your module
 - recent versions of npm >=5 have started throwing errors when they encounter the bundled tree of node-pre-gyp. It seems like the tree expectations changed and recent npm borks frequently (especially when package-lock.js is involed). Instead of try to fix npm (or understand the problem more deeply), let's just recommend not bundling to get around this.

Note: `prepublishOnly: npm ls` is no longer valuable since its intention was simply to check that bundling looked correct before publishing.
 
So far this has been working in node-sqlite3 and a bunch of other modules I've released recently without any errors. So, its time to land it here as best practice.

/cc @mapbox/core-tech 

refs https://github.com/mapbox/node-pre-gyp/pull/403