### PR TITLE
Add more info about package-lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Once your project has ported node-cpp-skel, follow these steps to integrate your
 - Add your new file-to-be-compiled to the list of target sources in `./binding.gyp`
 - Run `make` and see what surprises await on your new journey :boat:
 
+### Adding dependencies
+With updated versions of npm, a `package-lock.json` file is created, which is now included in node-cpp-skel. See [`npm-and-package-lock.md`](./docs/npm-and-package-lock.md) for more info on how to interact with this file and how to add new dependencies.
+
 # Code coverage
 
 Code coverage is critical for knowing how well your tests actually test all your code. To see code coverage you can view current results online at [![codecov](https://codecov.io/gh/mapbox/node-cpp-skel/branch/master/graph/badge.svg)](https://codecov.io/gh/mapbox/node-cpp-skel) or you can build in a customized way and display coverage locally like:

--- a/docs/npm-and-package-lock.md
+++ b/docs/npm-and-package-lock.md
@@ -16,7 +16,7 @@ With updated versions of npm, there is now such thing as a `package-lock.json` f
 
 Running `npm install` in a folder that contains a `package.json` file will create a `package-lock.json` file if one does not exist. **You should commit this file**.
 
-If a `package-lock.json` file exists in the repository, but some of the versions of dependencies are out-of-sync with what's specifed in `package.json` then running `npm install` will update the `package-lock.json` file. This may happen if you manually edited a version of a dependency in `package.json`, which you should not do (see below).
+If a `package-lock.json` file exists in the repository, but some of the versions of dependencies are out-of-sync with what's specified in `package.json` then running `npm install` will update the `package-lock.json` file. This may happen if you manually edited a version of a dependency in `package.json`, which you should not do (see below).
 
 If you are creating a PR, you should notice if that PR contains changes to `package-lock.json`, and you should be able to explain in the PR why those changes are being made.
 
@@ -25,6 +25,8 @@ To take full advantage of the explicit dependency versions specified in `package
 ```
 npm ci
 ```
+
+Note: this `ci` requires at least npm >= v5.7.1 (https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable).
 
 This will remove your existing `node_modules` folder, and then install the exact versions defined by `package-lock.json`. It will **never** make changes to `package.json` or `package-lock.json`, unlike `npm install`.
 
@@ -42,7 +44,7 @@ If you want to upgrade a dependency to the most recent version specified by the 
 npm update eslint
 ```
 
-If you want to remove a dependecy:
+If you want to remove a dependency:
 
 ```
 npm remove eslint

--- a/docs/npm-and-package-lock.md
+++ b/docs/npm-and-package-lock.md
@@ -1,0 +1,49 @@
+## Using npm, package.json, and package-lock.json
+
+With updated versions of npm, there is now such thing as a `package-lock.json` file, which is now included in node-cpp-skel. Read this doc for more info, also discussion at https://github.com/mapbox/node-cpp-skel/issues/124.
+
+`package.json` defines the dependencies required by any given library. It often defines a range of acceptable version of those dependencies, for example:
+
+```
+"dependencies": {
+    "eslint": "^4.3.0"
+}
+```
+
+... means that any version of eslint >4.3.0 and <5 is acceptable.
+
+`package-lock.json` defines _explicit versions of dependencies that should be used_. This is useful, because by using `package-lock.json` you can be confident that the version of your dependencies deployed in production matches exactly with the versions you install in your local testing environment.
+
+Running `npm install` in a folder that contains a `package.json` file will create a `package-lock.json` file if one does not exist. **You should commit this file**.
+
+If a `package-lock.json` file exists in the repository, but some of the versions of dependencies are out-of-sync with what's specifed in `package.json` then running `npm install` will update the `package-lock.json` file. This may happen if you manually edited a version of a dependency in `package.json`, which you should not do (see below).
+
+If you are creating a PR, you should notice if that PR contains changes to `package-lock.json`, and you should be able to explain in the PR why those changes are being made.
+
+To take full advantage of the explicit dependency versions specified in `package-lock.json`, don't use `npm install`. Instead, run
+
+```
+npm ci
+```
+
+This will remove your existing `node_modules` folder, and then install the exact versions defined by `package-lock.json`. It will **never** make changes to `package.json` or `package-lock.json`, unlike `npm install`.
+
+### Avoid editing package.json directly
+
+If you need to change the range of acceptable versions for a dependency:
+
+```
+npm install --save eslint@^4.4.8
+```
+
+If you want to upgrade a dependency to the most recent version specified by the existing range in `package.json`;
+
+```
+npm update eslint
+```
+
+If you want to remove a dependecy:
+
+```
+npm remove eslint
+```


### PR DESCRIPTION
Per https://github.com/mapbox/node-cpp-skel/issues/124, adding a new doc (from Platform) to the skel to clear some of this up. Also pondering if I should mention how `npm install` plays into running `make` here in the skel.

cc @mapbox/core-tech 