### PR TITLE
Upgrade mason deps

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,9 +1,9 @@
 ---
-Checks:          '*'
+Checks:          '*,-fuchsia-default-arguments'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '\/src\/'
 AnalyzeTemporaryDtors: false
-CheckOptions:    
+CheckOptions:
   - key:             google-readability-braces-around-statements.ShortStatementLines
     value:           '1'
   - key:             google-readability-function-size.StatementThreshold
@@ -25,4 +25,3 @@ CheckOptions:
   - key:             modernize-use-nullptr.NullMacros
     value:           'NULL'
 ...
-

--- a/mason-versions.ini
+++ b/mason-versions.ini
@@ -1,8 +1,8 @@
 [headers]
-protozero=1.6.1
+protozero=1.6.3
 [compiled]
-clang++=5.0.1
-clang-tidy=5.0.1
-clang-format=5.0.1
-llvm-cov=5.0.1
-binutils=2.30
+clang++=6.0.1
+clang-tidy=6.0.1
+clang-format=6.0.1
+llvm-cov=6.0.1
+binutils=2.31

--- a/package-lock.json
+++ b/package-lock.json
@@ -868,13 +868,14 @@
         "isarray": "1.0.0",
         "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
       },
       "dependencies": {
         "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "5.1.2"
           }

--- a/src/object_async/hello_async.cpp
+++ b/src/object_async/hello_async.cpp
@@ -205,7 +205,7 @@ struct AsyncHelloWorker : Nan::AsyncWorker // NOLINT to disable cppcoreguideline
         }
     }
 
-    std::unique_ptr<std::string> result_{};
+    std::unique_ptr<std::string> result_ = std::make_unique<std::string>();
     const bool louder_;
     const bool buffer_;
     // We use a pointer here to avoid copying the string data.

--- a/src/object_async/hello_async.cpp
+++ b/src/object_async/hello_async.cpp
@@ -162,7 +162,6 @@ struct AsyncHelloWorker : Nan::AsyncWorker // NOLINT to disable cppcoreguideline
                      const std::string* name,
                      Nan::Callback* cb)
         : Base(cb, "skel:object-async-worker"),
-          result_(),
           louder_(louder),
           buffer_(buffer),
           name_(name) {}
@@ -206,7 +205,7 @@ struct AsyncHelloWorker : Nan::AsyncWorker // NOLINT to disable cppcoreguideline
         }
     }
 
-    std::unique_ptr<std::string> result_;
+    std::unique_ptr<std::string> result_{};
     const bool louder_;
     const bool buffer_;
     // We use a pointer here to avoid copying the string data.

--- a/src/standalone_async/hello_async.cpp
+++ b/src/standalone_async/hello_async.cpp
@@ -114,7 +114,7 @@ struct AsyncHelloWorker : Nan::AsyncWorker {
         }
     }
 
-    std::unique_ptr<std::string> result_{};
+    std::unique_ptr<std::string> result_ = std::make_unique<std::string>();
     const bool louder_;
     const bool buffer_;
 };

--- a/src/standalone_async/hello_async.cpp
+++ b/src/standalone_async/hello_async.cpp
@@ -74,7 +74,7 @@ struct AsyncHelloWorker : Nan::AsyncWorker {
     using Base = Nan::AsyncWorker;
 
     AsyncHelloWorker(bool louder, bool buffer, Nan::Callback* cb)
-        : Base(cb, "skel:standalone-async-worker"), result_(), louder_(louder), buffer_(buffer) {}
+        : Base(cb, "skel:standalone-async-worker"), louder_(louder), buffer_(buffer) {}
 
     // The Execute() function is getting called when the worker starts to run.
     // - You only have access to member variables stored in this worker.
@@ -114,7 +114,7 @@ struct AsyncHelloWorker : Nan::AsyncWorker {
         }
     }
 
-    std::unique_ptr<std::string> result_;
+    std::unique_ptr<std::string> result_{};
     const bool louder_;
     const bool buffer_;
 };


### PR DESCRIPTION
This includes clang++ and clang-tidy packages that both no longer symlink the `c++` directory, which should avoid the (previous) problem with the llvm `6.0.0` packages mentioned at https://github.com/mapbox/node-cpp-skel/pull/146


refs https://github.com/mapbox/mason/pull/650