### PR TITLE
update protozero to 1.6.8 + llvm to 9.0.0

### DIFF
--- a/mason-versions.ini
+++ b/mason-versions.ini
@@ -1,8 +1,8 @@
 [headers]
-protozero=1.6.3
+protozero=1.6.8
 [compiled]
-clang++=7.0.0
-clang-tidy=7.0.0
-clang-format=7.0.0
-llvm-cov=7.0.0
+clang++=9.0.0
+clang-tidy=9.0.0
+clang-format=9.0.0
+llvm-cov=9.0.0
 binutils=2.31


### PR DESCRIPTION
Updates to latest compiler + protozero. This is working except for the clang-tidy build which is failing on new warnings.