### PR TITLE
Stop versioning on node_abi

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "module_path": "./lib/binding/",
     "host": "https://mapbox-node-binary.s3.amazonaws.com",
     "remote_path": "./{name}/v{version}/{configuration}/{toolset}/",
-    "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
+    "package_name": "{platform}-{arch}.tar.gz"
   }
 }


### PR DESCRIPTION
Now that N-API is used, binaries should be forward compatible and therefore versioning on node_abi is no longer necessary (as long as the same major N-API version in involved).